### PR TITLE
Document all API endpoints in Swagger

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -10,6 +10,8 @@ info:
 servers:
   - url: http://localhost:3001/api
     description: Development server
+  - url: http://localhost:3001
+    description: Development root
   - url: https://api.apexmma.com
     description: Production server
 
@@ -26,6 +28,16 @@ tags:
     description: E-commerce operations
   - name: User
     description: User profile and account management
+  - name: Bookings
+    description: Class and session bookings
+  - name: Membership Plans
+    description: Membership plan management
+  - name: Private Sessions
+    description: Personal training sessions
+  - name: Webhooks
+    description: External service webhooks
+  - name: Health
+    description: Service health checks
 
 paths:
   /content/{key}:
@@ -222,6 +234,462 @@ paths:
                         type: string
                       user:
                         $ref: '#/components/schemas/User'
+  /auth/register:
+    post:
+      tags: [Auth]
+      summary: Register a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, password, name]
+              properties:
+                email:
+                  type: string
+                  format: email
+                password:
+                  type: string
+                name:
+                  type: string
+                phone:
+                  type: string
+      responses:
+        '201':
+          description: User registered successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /coaches/{id}:
+    get:
+      tags: [Coaches]
+      summary: Get coach by ID
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Coach details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Coach'
+        '404':
+          description: Coach not found
+
+  /coaches/{id}/availability:
+    get:
+      tags: [Coaches]
+      summary: Get coach availability
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: from
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: to
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: Available time slots
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          description: Coach not found
+
+  /bookings:
+    post:
+      tags: [Bookings]
+      summary: Create a booking
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [userId, sessionId]
+              properties:
+                userId:
+                  type: string
+                sessionId:
+                  type: string
+      responses:
+        '201':
+          description: Booking created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /bookings/{id}:
+    delete:
+      tags: [Bookings]
+      summary: Cancel a booking
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Booking cancelled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          description: Booking not found
+
+  /membership-plans:
+    get:
+      tags: [Membership Plans]
+      summary: List membership plans
+      responses:
+        '200':
+          description: List of plans
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    post:
+      tags: [Membership Plans]
+      summary: Create a membership plan
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '201':
+          description: Plan created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /membership-plans/{id}:
+    get:
+      tags: [Membership Plans]
+      summary: Get membership plan
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Plan details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          description: Plan not found
+    put:
+      tags: [Membership Plans]
+      summary: Update membership plan
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Plan updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          description: Plan not found
+    delete:
+      tags: [Membership Plans]
+      summary: Delete membership plan
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Plan deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          description: Plan not found
+
+  /private-sessions:
+    post:
+      tags: [Private Sessions]
+      summary: Book a private session
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [userId, coachId, startAt, endAt]
+              properties:
+                userId:
+                  type: string
+                coachId:
+                  type: string
+                startAt:
+                  type: string
+                  format: date-time
+                endAt:
+                  type: string
+                  format: date-time
+                notes:
+                  type: string
+      responses:
+        '201':
+          description: Private session booked
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /private-sessions/{id}/cancel:
+    post:
+      tags: [Private Sessions]
+      summary: Cancel a private session
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Session cancelled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          description: Session not found
+
+  /shop/categories:
+    get:
+      tags: [Shop]
+      summary: List product categories
+      responses:
+        '200':
+          description: Category list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /shop/products:
+    get:
+      tags: [Shop]
+      summary: List products with filters
+      parameters:
+        - in: query
+          name: query
+          schema:
+            type: string
+        - in: query
+          name: categoryId
+          schema:
+            type: string
+        - in: query
+          name: inStock
+          schema:
+            type: boolean
+        - in: query
+          name: sort
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: integer
+        - in: query
+          name: limit
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Product list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /shop/products/{id}:
+    get:
+      tags: [Shop]
+      summary: Get product by ID
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Product details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          description: Product not found
+
+  /shop/cart:
+    post:
+      tags: [Shop]
+      summary: Calculate cart totals
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Cart calculated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /shop/whatsapp-config:
+    get:
+      tags: [Shop]
+      summary: Get WhatsApp order configuration
+      responses:
+        '200':
+          description: Configuration data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /me:
+    get:
+      tags: [User]
+      summary: Get current user profile
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: User profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /me/bookings:
+    get:
+      tags: [User]
+      summary: Get current user's bookings
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Booking list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /me/orders:
+    get:
+      tags: [User]
+      summary: Get current user's orders
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Order list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /webhooks/stripe:
+    post:
+      tags: [Webhooks]
+      summary: Handle Stripe webhooks
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Webhook received
+
+  /health:
+    get:
+      tags: [Health]
+      summary: Health check
+      responses:
+        '200':
+          description: Service status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  timestamp:
+                    type: string
+                    format: date-time
 
 components:
   schemas:


### PR DESCRIPTION
## Summary
- expand API docs with missing routes including bookings, membership plans, private sessions, shop, user profile, webhooks and health
- document additional auth and coach endpoints

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bab2cb95cc832d8ba334e44f518e21