### PR TITLE
feat: add admin content listing endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { bookingRoutes } from './routes/bookings';
 import { classRoutes } from './routes/classes';
 import { coachRoutes } from './routes/coaches';
 import { contentRoutes } from './routes/content';
+import { adminRoutes } from './routes/admin';
 import { membershipPlanRoutes } from './routes/membership-plans';
 import { privateSessionRoutes } from './routes/private-sessions';
 import { shopRoutes } from './routes/shop';
@@ -74,6 +75,7 @@ app.get('/health', (req, res) => {
 });
 
 // API Routes
+app.use('/api/admin', adminRoutes);
 app.use('/api/content', contentRoutes);
 app.use('/api/classes', classRoutes);
 app.use('/api/coaches', coachRoutes);

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,0 +1,110 @@
+import express from 'express';
+import { requireAdmin } from '../middleware/requireAdmin';
+import { ContentService } from '../services/contentService';
+import { ClassService } from '../services/classService';
+import { ProductService } from '../services/productService';
+import { ApiResponse } from '../types';
+
+const router = express.Router();
+
+// Apply admin middleware to all routes
+router.use(requireAdmin);
+
+// GET /api/admin/content
+router.get('/content', async (req, res) => {
+  const locale = (req.query.locale as string) || 'en';
+
+  try {
+    const content = await ContentService.getAllContent(locale);
+
+    const response: ApiResponse<any> = {
+      data: content,
+    };
+
+    res.json(response);
+  } catch (error) {
+    console.error('Error fetching content:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to fetch content'
+    });
+  }
+});
+
+// GET /api/admin/disciplines
+router.get('/disciplines', async (req, res) => {
+  try {
+    const disciplines = await ClassService.getAllDisciplines();
+
+    const response: ApiResponse<any> = {
+      data: disciplines,
+    };
+
+    res.json(response);
+  } catch (error) {
+    console.error('Error fetching disciplines:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to fetch disciplines'
+    });
+  }
+});
+
+// GET /api/admin/class-templates
+router.get('/class-templates', async (req, res) => {
+  try {
+    const templates = await ClassService.getClassTemplates({});
+
+    const response: ApiResponse<any> = {
+      data: templates,
+    };
+
+    res.json(response);
+  } catch (error) {
+    console.error('Error fetching class templates:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to fetch class templates'
+    });
+  }
+});
+
+// GET /api/admin/class-sessions
+router.get('/class-sessions', async (req, res) => {
+  try {
+    const sessions = await ClassService.getClassSessions({});
+
+    const response: ApiResponse<any> = {
+      data: sessions,
+    };
+
+    res.json(response);
+  } catch (error) {
+    console.error('Error fetching class sessions:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to fetch class sessions'
+    });
+  }
+});
+
+// GET /api/admin/product-categories
+router.get('/product-categories', async (req, res) => {
+  try {
+    const categories = await ProductService.getAllCategories();
+
+    const response: ApiResponse<any> = {
+      data: categories,
+    };
+
+    res.json(response);
+  } catch (error) {
+    console.error('Error fetching product categories:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to fetch product categories'
+    });
+  }
+});
+
+export { router as adminRoutes };

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -38,8 +38,101 @@ tags:
     description: External service webhooks
   - name: Health
     description: Service health checks
+  - name: Admin
+    description: Administrative endpoints
 
 paths:
+  /admin/content:
+    get:
+      tags: [Admin]
+      summary: List all content blocks
+      parameters:
+        - in: query
+          name: locale
+          schema:
+            type: string
+            default: en
+      responses:
+        '200':
+          description: List of content blocks
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ContentBlock'
+
+  /admin/disciplines:
+    get:
+      tags: [Admin]
+      summary: List all disciplines
+      responses:
+        '200':
+          description: List of disciplines
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ClassDiscipline'
+
+  /admin/class-templates:
+    get:
+      tags: [Admin]
+      summary: List all class templates
+      responses:
+        '200':
+          description: List of class templates
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ClassTemplate'
+
+  /admin/class-sessions:
+    get:
+      tags: [Admin]
+      summary: List all class sessions
+      responses:
+        '200':
+          description: List of class sessions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ClassSession'
+
+  /admin/product-categories:
+    get:
+      tags: [Admin]
+      summary: List product categories
+      responses:
+        '200':
+          description: List of product categories
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ProductCategory'
+
   /content/{key}:
     get:
       tags: [Content]
@@ -798,6 +891,40 @@ components:
         status:
           type: string
           enum: [scheduled, cancelled, full, in_progress, completed]
+
+    ContentBlock:
+      type: object
+      required: [id, key, locale, json]
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        locale:
+          type: string
+        json:
+          type: object
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    ProductCategory:
+      type: object
+      required: [id, name, slug]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        slug:
+          type: string
+        description:
+          type: string
+        parentId:
+          type: string
 
     Coach:
       type: object


### PR DESCRIPTION
## Summary
- add admin routes to list content, disciplines, templates, sessions, and product categories
- register admin routes and document in Swagger

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bab91c8170832dbe68875d11c45183