### PR TITLE
feat: add admin content update and delete endpoints

### DIFF
--- a/src/services/contentService.ts
+++ b/src/services/contentService.ts
@@ -14,6 +14,10 @@ export class ContentService {
     );
   }
 
+  static async deleteContent(key: string, locale: string): Promise<any | null> {
+    return ContentBlock.findOneAndDelete({ key, locale });
+  }
+
   static async getAllContent(locale: string = 'en'): Promise<any[]> {
     return ContentBlock.find({ locale }).sort({ key: 1 });
   }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -156,6 +156,62 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+    put:
+      tags: [Content]
+      summary: Update content block
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: key
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [locale, json]
+              properties:
+                locale:
+                  type: string
+                  default: en
+                json:
+                  type: object
+      responses:
+        '200':
+          description: Content block updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    delete:
+      tags: [Content]
+      summary: Delete content block
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: key
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: locale
+          schema:
+            type: string
+            default: en
+      responses:
+        '200':
+          description: Content block deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          description: Content block not found
 
   /classes/disciplines:
     get:


### PR DESCRIPTION
## Summary
- allow admins to update content blocks via PUT /api/content/:key
- allow admins to delete content blocks via DELETE /api/content/:key
- document new content endpoints in swagger

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bac4612f4c832db4e3cd2559d6b2c0