### PR TITLE
Add protected create, update and delete endpoints

### DIFF
--- a/src/routes/classes.ts
+++ b/src/routes/classes.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { ClassService } from '../services/classService';
 import { ApiResponse, ClassSession } from '../types';
+import { requireAdmin } from '../middleware/requireAdmin';
 
 const router = express.Router();
 
@@ -18,6 +19,65 @@ router.get('/disciplines', async (req, res) => {
     res.status(500).json({
       error: 'Internal Server Error',
       message: 'Failed to fetch disciplines'
+    });
+  }
+});
+
+// POST /api/classes/disciplines
+router.post('/disciplines', requireAdmin, async (req, res) => {
+  try {
+    const discipline = await ClassService.createDiscipline(req.body);
+    const response: ApiResponse<any> = { data: discipline };
+    res.status(201).json(response);
+  } catch (error) {
+    console.error('Error creating discipline:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to create discipline'
+    });
+  }
+});
+
+// PUT /api/classes/disciplines/:id
+router.put('/disciplines/:id', requireAdmin, async (req, res) => {
+  const { id } = req.params;
+  try {
+    const discipline = await ClassService.updateDiscipline(id, req.body);
+    if (!discipline) {
+      return res.status(404).json({
+        error: 'Discipline Not Found',
+        message: `Discipline with id "${id}" not found`,
+      });
+    }
+    const response: ApiResponse<any> = { data: discipline };
+    res.json(response);
+  } catch (error) {
+    console.error('Error updating discipline:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to update discipline'
+    });
+  }
+});
+
+// DELETE /api/classes/disciplines/:id
+router.delete('/disciplines/:id', requireAdmin, async (req, res) => {
+  const { id } = req.params;
+  try {
+    const discipline = await ClassService.deleteDiscipline(id);
+    if (!discipline) {
+      return res.status(404).json({
+        error: 'Discipline Not Found',
+        message: `Discipline with id "${id}" not found`,
+      });
+    }
+    const response: ApiResponse<any> = { data: { success: true } };
+    res.json(response);
+  } catch (error) {
+    console.error('Error deleting discipline:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to delete discipline'
     });
   }
 });
@@ -43,6 +103,21 @@ router.get('/templates', async (req, res) => {
     res.status(500).json({
       error: 'Internal Server Error',
       message: 'Failed to fetch templates'
+    });
+  }
+});
+
+// POST /api/classes/templates
+router.post('/templates', requireAdmin, async (req, res) => {
+  try {
+    const template = await ClassService.createClassTemplate(req.body);
+    const response: ApiResponse<any> = { data: template };
+    res.status(201).json(response);
+  } catch (error) {
+    console.error('Error creating template:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to create template'
     });
   }
 });
@@ -75,6 +150,50 @@ router.get('/templates/:id', async (req, res) => {
   }
 });
 
+// PUT /api/classes/templates/:id
+router.put('/templates/:id', requireAdmin, async (req, res) => {
+  const { id } = req.params;
+  try {
+    const template = await ClassService.updateClassTemplate(id, req.body);
+    if (!template) {
+      return res.status(404).json({
+        error: 'Class Template Not Found',
+        message: `Class template with id "${id}" not found`,
+      });
+    }
+    const response: ApiResponse<any> = { data: template };
+    res.json(response);
+  } catch (error) {
+    console.error('Error updating template:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to update template'
+    });
+  }
+});
+
+// DELETE /api/classes/templates/:id
+router.delete('/templates/:id', requireAdmin, async (req, res) => {
+  const { id } = req.params;
+  try {
+    const template = await ClassService.deleteClassTemplate(id);
+    if (!template) {
+      return res.status(404).json({
+        error: 'Class Template Not Found',
+        message: `Class template with id "${id}" not found`,
+      });
+    }
+    const response: ApiResponse<any> = { data: { success: true } };
+    res.json(response);
+  } catch (error) {
+    console.error('Error deleting template:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to delete template'
+    });
+  }
+});
+
 // GET /api/classes/sessions
 router.get('/sessions', async (req, res) => {
   const { from, to, discipline, level, coachId, locationId } = req.query;
@@ -99,6 +218,65 @@ router.get('/sessions', async (req, res) => {
     res.status(500).json({
       error: 'Internal Server Error',
       message: 'Failed to fetch sessions'
+    });
+  }
+});
+
+// POST /api/classes/sessions
+router.post('/sessions', requireAdmin, async (req, res) => {
+  try {
+    const session = await ClassService.createClassSession(req.body);
+    const response: ApiResponse<any> = { data: session };
+    res.status(201).json(response);
+  } catch (error) {
+    console.error('Error creating session:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to create session'
+    });
+  }
+});
+
+// PUT /api/classes/sessions/:id
+router.put('/sessions/:id', requireAdmin, async (req, res) => {
+  const { id } = req.params;
+  try {
+    const session = await ClassService.updateClassSession(id, req.body);
+    if (!session) {
+      return res.status(404).json({
+        error: 'Class Session Not Found',
+        message: `Class session with id "${id}" not found`,
+      });
+    }
+    const response: ApiResponse<any> = { data: session };
+    res.json(response);
+  } catch (error) {
+    console.error('Error updating session:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to update session'
+    });
+  }
+});
+
+// DELETE /api/classes/sessions/:id
+router.delete('/sessions/:id', requireAdmin, async (req, res) => {
+  const { id } = req.params;
+  try {
+    const session = await ClassService.deleteClassSession(id);
+    if (!session) {
+      return res.status(404).json({
+        error: 'Class Session Not Found',
+        message: `Class session with id "${id}" not found`,
+      });
+    }
+    const response: ApiResponse<any> = { data: { success: true } };
+    res.json(response);
+  } catch (error) {
+    console.error('Error deleting session:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to delete session'
     });
   }
 });

--- a/src/routes/coaches.ts
+++ b/src/routes/coaches.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { CoachService } from '../services/coachService';
 import { ApiResponse } from '../types';
+import { requireAdmin } from '../middleware/requireAdmin';
 
 const router = express.Router();
 
@@ -21,6 +22,21 @@ router.get('/', async (req, res) => {
     res.status(500).json({
       error: 'Internal Server Error',
       message: 'Failed to fetch coaches'
+    });
+  }
+});
+
+// POST /api/coaches
+router.post('/', requireAdmin, async (req, res) => {
+  try {
+    const coach = await CoachService.createCoach(req.body);
+    const response: ApiResponse<any> = { data: coach };
+    res.status(201).json(response);
+  } catch (error) {
+    console.error('Error creating coach:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to create coach'
     });
   }
 });
@@ -49,6 +65,50 @@ router.get('/:id', async (req, res) => {
     res.status(500).json({
       error: 'Internal Server Error',
       message: 'Failed to fetch coach'
+    });
+  }
+});
+
+// PUT /api/coaches/:id
+router.put('/:id', requireAdmin, async (req, res) => {
+  const { id } = req.params;
+  try {
+    const coach = await CoachService.updateCoach(id, req.body);
+    if (!coach) {
+      return res.status(404).json({
+        error: 'Coach Not Found',
+        message: `Coach with id "${id}" not found`,
+      });
+    }
+    const response: ApiResponse<any> = { data: coach };
+    res.json(response);
+  } catch (error) {
+    console.error('Error updating coach:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to update coach'
+    });
+  }
+});
+
+// DELETE /api/coaches/:id
+router.delete('/:id', requireAdmin, async (req, res) => {
+  const { id } = req.params;
+  try {
+    const coach = await CoachService.deleteCoach(id);
+    if (!coach) {
+      return res.status(404).json({
+        error: 'Coach Not Found',
+        message: `Coach with id "${id}" not found`,
+      });
+    }
+    const response: ApiResponse<any> = { data: { success: true } };
+    res.json(response);
+  } catch (error) {
+    console.error('Error deleting coach:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to delete coach'
     });
   }
 });

--- a/src/routes/shop.ts
+++ b/src/routes/shop.ts
@@ -64,6 +64,21 @@ router.get('/products', async (req, res) => {
   }
 });
 
+// POST /api/shop/products
+router.post('/products', requireAdmin, async (req, res) => {
+  try {
+    const product = await ProductService.createProduct(req.body);
+    const response: ApiResponse<any> = { data: product };
+    res.status(201).json(response);
+  } catch (error) {
+    console.error('Error creating product:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to create product'
+    });
+  }
+});
+
 // GET /api/shop/products/:id
 router.get('/products/:id', async (req, res) => {
   const { id } = req.params;
@@ -88,6 +103,50 @@ router.get('/products/:id', async (req, res) => {
     res.status(500).json({
       error: 'Internal Server Error',
       message: 'Failed to fetch product'
+    });
+  }
+});
+
+// PUT /api/shop/products/:id
+router.put('/products/:id', requireAdmin, async (req, res) => {
+  const { id } = req.params;
+  try {
+    const product = await ProductService.updateProduct(id, req.body);
+    if (!product) {
+      return res.status(404).json({
+        error: 'Product Not Found',
+        message: `Product with id "${id}" not found`,
+      });
+    }
+    const response: ApiResponse<any> = { data: product };
+    res.json(response);
+  } catch (error) {
+    console.error('Error updating product:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to update product'
+    });
+  }
+});
+
+// DELETE /api/shop/products/:id
+router.delete('/products/:id', requireAdmin, async (req, res) => {
+  const { id } = req.params;
+  try {
+    const product = await ProductService.deleteProduct(id);
+    if (!product) {
+      return res.status(404).json({
+        error: 'Product Not Found',
+        message: `Product with id "${id}" not found`,
+      });
+    }
+    const response: ApiResponse<any> = { data: { success: true } };
+    res.json(response);
+  } catch (error) {
+    console.error('Error deleting product:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to delete product'
     });
   }
 });

--- a/src/services/classService.ts
+++ b/src/services/classService.ts
@@ -1,8 +1,12 @@
-import { ClassDiscipline, ClassTemplate, ClassSession, Coach } from '../models';
+import { ClassDiscipline, ClassTemplate, ClassSession, IClassDiscipline, IClassTemplate, IClassSession } from '../models';
 
 export class ClassService {
   static async getAllDisciplines(): Promise<any[]> {
     return ClassDiscipline.find({}).sort({ name: 1 });
+  }
+
+  static async createDiscipline(data: IClassDiscipline): Promise<any> {
+    return ClassDiscipline.create(data);
   }
 
   static async getClassTemplates(filters: {
@@ -37,6 +41,10 @@ export class ClassService {
     return ClassTemplate.findById(id)
       .populate('disciplineId', 'name slug')
       .populate('coachIds', 'name photo specialties');
+  }
+
+  static async createClassTemplate(data: IClassTemplate): Promise<any> {
+    return ClassTemplate.create(data);
   }
 
   static async getClassSessions(filters: {
@@ -93,5 +101,33 @@ export class ClassService {
     }
     
     return sessions;
+  }
+
+  static async createClassSession(data: IClassSession): Promise<any> {
+    return ClassSession.create(data);
+  }
+
+  static async updateDiscipline(id: string, data: Partial<IClassDiscipline>): Promise<any | null> {
+    return ClassDiscipline.findByIdAndUpdate(id, data, { new: true });
+  }
+
+  static async deleteDiscipline(id: string): Promise<any | null> {
+    return ClassDiscipline.findByIdAndDelete(id);
+  }
+
+  static async updateClassTemplate(id: string, data: Partial<IClassTemplate>): Promise<any | null> {
+    return ClassTemplate.findByIdAndUpdate(id, data, { new: true });
+  }
+
+  static async deleteClassTemplate(id: string): Promise<any | null> {
+    return ClassTemplate.findByIdAndDelete(id);
+  }
+
+  static async updateClassSession(id: string, data: Partial<IClassSession>): Promise<any | null> {
+    return ClassSession.findByIdAndUpdate(id, data, { new: true });
+  }
+
+  static async deleteClassSession(id: string): Promise<any | null> {
+    return ClassSession.findByIdAndDelete(id);
   }
 }

--- a/src/services/coachService.ts
+++ b/src/services/coachService.ts
@@ -1,4 +1,4 @@
-import { Coach } from '../models';
+import { Coach, ICoach } from '../models';
 import { ApiResponse } from '../types';
 
 export class CoachService {
@@ -17,6 +17,18 @@ export class CoachService {
 
   static async getCoachById(id: string): Promise<Coach | null> {
     return Coach.findOne({ _id: id, isActive: true });
+  }
+
+  static async createCoach(data: ICoach): Promise<Coach> {
+    return Coach.create(data);
+  }
+
+  static async updateCoach(id: string, data: Partial<ICoach>): Promise<Coach | null> {
+    return Coach.findByIdAndUpdate(id, data, { new: true });
+  }
+
+  static async deleteCoach(id: string): Promise<Coach | null> {
+    return Coach.findByIdAndUpdate(id, { isActive: false }, { new: true });
   }
 
   static async getCoachAvailability(

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -1,4 +1,4 @@
-import { Product, ProductCategory } from '../models';
+import { Product, ProductCategory, IProduct } from '../models';
 
 export class ProductService {
   static async getAllCategories(): Promise<any[]> {
@@ -67,5 +67,17 @@ export class ProductService {
   static async getProductById(id: string): Promise<any | null> {
     return Product.findOne({ _id: id, isActive: true })
       .populate('categoryId', 'name slug');
+  }
+
+  static async createProduct(data: IProduct): Promise<any> {
+    return Product.create(data);
+  }
+
+  static async updateProduct(id: string, data: Partial<IProduct>): Promise<any | null> {
+    return Product.findByIdAndUpdate(id, data, { new: true });
+  }
+
+  static async deleteProduct(id: string): Promise<any | null> {
+    return Product.findByIdAndUpdate(id, { isActive: false }, { new: true });
   }
 }


### PR DESCRIPTION
## Summary
- add admin-only creation routes for coaches, class assets and shop products
- expand services with create helpers for coaches, disciplines, templates, sessions and products

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bac927b86c832d9e10be1315593d28