### PR TITLE
feat: add coaching session and monthly payment API

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "nodemon": "^3.1.10",
     "swagger-ui-express": "^5.0.1",
     "tsx": "^4.20.5",
-    "yamljs": "^0.3.0"
+    "yamljs": "^0.3.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^24.3.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ import { privateSessionRoutes } from './routes/private-sessions';
 import { shopRoutes } from './routes/shop';
 import { userRoutes } from './routes/user';
 import { webhookRoutes } from './routes/webhooks';
+import { coachingSessionRoutes } from './routes/coaching-sessions';
+import { paymentRoutes } from './routes/payment';
 
 // ESM-safe __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -83,9 +85,11 @@ app.use('/api/auth', authRoutes);
 app.use('/api/shop', shopRoutes);
 app.use('/api/bookings', bookingRoutes);
 app.use('/api/membership-plans', membershipPlanRoutes);
+app.use('/api/coaching-sessions', coachingSessionRoutes);
 app.use('/api/private-sessions', privateSessionRoutes);
 app.use('/api/me', userRoutes);
 app.use('/webhooks', webhookRoutes);
+app.use('/api', paymentRoutes);
 
 // 404 handler
 // app.use('*', (req, res) => {

--- a/src/models/CoachingSession.ts
+++ b/src/models/CoachingSession.ts
@@ -1,0 +1,32 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface ICoachingSession extends Document {
+  name: string;
+  coach?: mongoose.Types.ObjectId;
+  coachModel?: 'Coach' | 'User';
+  date: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const coachingSessionSchema = new Schema<ICoachingSession>({
+  name: { type: String, required: true, trim: true },
+  coach: { type: Schema.Types.ObjectId, refPath: 'coachModel' },
+  coachModel: {
+    type: String,
+    enum: ['Coach', 'User'],
+    required: function(this: ICoachingSession) {
+      return !!this.coach;
+    }
+  },
+  date: { type: Date, required: true }
+}, {
+  timestamps: true
+});
+
+// Indexes
+coachingSessionSchema.index({ coach: 1 });
+coachingSessionSchema.index({ date: 1 });
+
+export const CoachingSession = mongoose.model<ICoachingSession>('CoachingSession', coachingSessionSchema);
+

--- a/src/models/Payment.ts
+++ b/src/models/Payment.ts
@@ -1,0 +1,24 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface IPayment extends Document {
+  amount: number;
+  currency: string;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const paymentSchema = new Schema<IPayment>({
+  amount: { type: Number, required: true, min: 0 },
+  currency: { type: String, required: true, uppercase: true, trim: true },
+  status: { type: String, required: true }
+}, {
+  timestamps: true
+});
+
+// Indexes
+paymentSchema.index({ createdAt: 1 });
+paymentSchema.index({ status: 1 });
+
+export const Payment = mongoose.model<IPayment>('Payment', paymentSchema);
+

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -9,3 +9,5 @@ export { ContentBlock, type IContentBlock } from './ContentBlock';
 export { Booking, type IBooking } from './Booking';
 export { PrivateSession, type IPrivateSession } from './PrivateSession';
 export { MembershipPlan, type IMembershipPlan } from './MembershipPlan';
+export { CoachingSession, type ICoachingSession } from './CoachingSession';
+export { Payment, type IPayment } from './Payment';

--- a/src/routes/coaching-sessions.ts
+++ b/src/routes/coaching-sessions.ts
@@ -1,0 +1,114 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import { z, ZodError, ZodSchema } from 'zod';
+import { CoachingSession } from '../models';
+
+const router = express.Router();
+
+const objectId = z.string().refine((val) => mongoose.Types.ObjectId.isValid(val), { message: 'Invalid id' });
+
+const createSchema = z.object({
+  name: z.string().min(1),
+  coach: objectId.optional(),
+  coachModel: z.enum(['Coach', 'User']).optional(),
+  date: z.coerce.date()
+}).refine((data) => (!data.coach && !data.coachModel) || (data.coach && data.coachModel), {
+  message: 'coach and coachModel must be provided together'
+});
+
+const updateSchema = createSchema.partial();
+
+const listSchema = z.object({
+  coach: objectId.optional(),
+  from: z.coerce.date().optional(),
+  to: z.coerce.date().optional(),
+});
+
+const idSchema = z.object({ id: objectId });
+
+function validate(schema: ZodSchema<any>, property: 'body' | 'query' | 'params' = 'body') {
+  return (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    try {
+      (req as any)[property] = schema.parse((req as any)[property]);
+      next();
+    } catch (err) {
+      const error = err as ZodError;
+      res.status(400).json({
+        error: 'Validation Error',
+        message: error.errors.map(e => e.message).join(', ')
+      });
+    }
+  };
+}
+
+// POST /api/coaching-sessions
+router.post('/', validate(createSchema), async (req, res) => {
+  try {
+    const session = await CoachingSession.create(req.body);
+    res.status(201).json(session);
+  } catch (err) {
+    res.status(500).json({ error: 'Internal Server Error', message: 'Failed to create coaching session' });
+  }
+});
+
+// GET /api/coaching-sessions
+router.get('/', validate(listSchema, 'query'), async (req, res) => {
+  const { coach, from, to } = req.query as any;
+  const filter: any = {};
+  if (coach) {
+    filter.coach = coach;
+  }
+  if (from || to) {
+    filter.date = {};
+    if (from) filter.date.$gte = from;
+    if (to) filter.date.$lte = to;
+  }
+  try {
+    const sessions = await CoachingSession.find(filter);
+    res.json(sessions);
+  } catch (err) {
+    res.status(500).json({ error: 'Internal Server Error', message: 'Failed to fetch coaching sessions' });
+  }
+});
+
+// GET /api/coaching-sessions/:id
+router.get('/:id', validate(idSchema, 'params'), async (req, res) => {
+  try {
+    const session = await CoachingSession.findById(req.params.id);
+    if (!session) {
+      return res.status(404).json({ error: 'Not Found', message: 'Coaching session not found' });
+    }
+    res.json(session);
+  } catch (err) {
+    res.status(500).json({ error: 'Internal Server Error', message: 'Failed to fetch coaching session' });
+  }
+});
+
+// PATCH /api/coaching-sessions/:id
+router.patch('/:id', validate(idSchema, 'params'), validate(updateSchema), async (req, res) => {
+  try {
+    const session = await CoachingSession.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!session) {
+      return res.status(404).json({ error: 'Not Found', message: 'Coaching session not found' });
+    }
+    res.json(session);
+  } catch (err) {
+    res.status(500).json({ error: 'Internal Server Error', message: 'Failed to update coaching session' });
+  }
+});
+
+// DELETE /api/coaching-sessions/:id
+router.delete('/:id', validate(idSchema, 'params'), async (req, res) => {
+  try {
+    const session = await CoachingSession.findByIdAndDelete(req.params.id);
+    if (!session) {
+      return res.status(404).json({ error: 'Not Found', message: 'Coaching session not found' });
+    }
+    res.status(204).send();
+  } catch (err) {
+    res.status(500).json({ error: 'Internal Server Error', message: 'Failed to delete coaching session' });
+  }
+});
+
+export { router as coachingSessionRoutes };
+

--- a/src/routes/payment.ts
+++ b/src/routes/payment.ts
@@ -1,0 +1,40 @@
+import express from 'express';
+import { startOfMonth, endOfMonth } from 'date-fns';
+import { Payment } from '../models';
+
+const router = express.Router();
+
+// GET /api/payment
+router.get('/payment', async (req, res) => {
+  const now = new Date();
+  const start = startOfMonth(now);
+  const end = endOfMonth(now);
+
+  try {
+    const match = {
+      status: { $ne: 'failed' },
+      createdAt: { $gte: start, $lte: end }
+    };
+
+    const items = await Payment.find(match);
+
+    const summary = await Payment.aggregate([
+      { $match: match },
+      { $group: { _id: '$currency', totalAmount: { $sum: '$amount' }, count: { $sum: 1 } } }
+    ]);
+
+    res.json({
+      items,
+      summary,
+      range: {
+        start: start.toISOString(),
+        end: end.toISOString()
+      }
+    });
+  } catch (err) {
+    res.status(500).json({ error: 'Internal Server Error', message: 'Failed to fetch payments' });
+  }
+});
+
+export { router as paymentRoutes };
+


### PR DESCRIPTION
## Summary
- add Mongoose model for CoachingSession with indexes
- implement CRUD endpoints with Zod validation under `/api/coaching-sessions`
- create Payment model and monthly payment report endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0586a0f08832da0ec08291c573981