### PR TITLE
feat: add coach earnings endpoint

### DIFF
--- a/src/data/privateSessions.ts
+++ b/src/data/privateSessions.ts
@@ -1,0 +1,5 @@
+import { PrivateSession } from '../types';
+
+// In-memory storage for private sessions
+export const privateSessions: PrivateSession[] = [];
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { userRoutes } from './routes/user';
 import { webhookRoutes } from './routes/webhooks';
 import { coachingSessionRoutes } from './routes/coaching-sessions';
 import { paymentRoutes } from './routes/payment';
+import { coachEarningsRoutes } from './routes/coach-earnings';
 
 // ESM-safe __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -87,6 +88,7 @@ app.use('/api/bookings', bookingRoutes);
 app.use('/api/membership-plans', membershipPlanRoutes);
 app.use('/api/coaching-sessions', coachingSessionRoutes);
 app.use('/api/private-sessions', privateSessionRoutes);
+app.use('/api/coach-earnings', coachEarningsRoutes);
 app.use('/api/me', userRoutes);
 app.use('/webhooks', webhookRoutes);
 app.use('/api', paymentRoutes);

--- a/src/routes/coach-earnings.ts
+++ b/src/routes/coach-earnings.ts
@@ -1,0 +1,60 @@
+import express from 'express';
+import { privateSessions } from '../data/privateSessions';
+import { PrivateSession, PrivateSessionStatus, ApiResponse } from '../types';
+
+const router = express.Router();
+
+// GET /api/coach-earnings?month=MM&year=YYYY
+router.get('/', (req, res) => {
+  const { month, year } = req.query;
+
+  if (!month || !year) {
+    return res.status(400).json({
+      error: 'Validation Error',
+      message: 'month and year are required',
+    });
+  }
+
+  const monthNum = parseInt(month as string, 10);
+  const yearNum = parseInt(year as string, 10);
+
+  if (isNaN(monthNum) || monthNum < 1 || monthNum > 12 || isNaN(yearNum)) {
+    return res.status(400).json({
+      error: 'Validation Error',
+      message: 'Invalid month or year',
+    });
+  }
+
+  const earningsMap: Record<string, { coachId: string; totalEarnings: number; sessions: PrivateSession[] }> = {};
+
+  privateSessions.forEach((session) => {
+    const date = new Date(session.startAt);
+    const sessionMonth = date.getMonth() + 1; // getMonth is 0-indexed
+    const sessionYear = date.getFullYear();
+
+    if (
+      sessionMonth === monthNum &&
+      sessionYear === yearNum &&
+      session.status !== PrivateSessionStatus.CANCELLED
+    ) {
+      if (!earningsMap[session.coachId]) {
+        earningsMap[session.coachId] = {
+          coachId: session.coachId,
+          totalEarnings: 0,
+          sessions: [],
+        };
+      }
+      earningsMap[session.coachId].totalEarnings += session.price;
+      earningsMap[session.coachId].sessions.push(session);
+    }
+  });
+
+  const data = Object.values(earningsMap);
+
+  const response: ApiResponse<typeof data> = { data };
+
+  res.json(response);
+});
+
+export { router as coachEarningsRoutes };
+

--- a/src/routes/private-sessions.ts
+++ b/src/routes/private-sessions.ts
@@ -3,11 +3,9 @@ import { PrivateSession, PrivateSessionStatus } from '../types';
 import { coaches } from '../data/coaches';
 import { ApiResponse } from '../types';
 import { requireAdmin } from '../middleware/requireAdmin';
+import { privateSessions } from '../data/privateSessions';
 
 const router = express.Router();
-
-// Mock private sessions storage
-const privateSessions: PrivateSession[] = [];
 
 // POST /api/private-sessions
 router.post('/', requireAdmin, (req, res) => {


### PR DESCRIPTION
## Summary
- add in-memory storage for private sessions
- compute coach earnings by month with session details
- expose coach earnings route and integrate with existing sessions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c05f18e0c8832d847e8a02f7f0de9e