### PR TITLE
Fix update schema in coaching sessions route

### DIFF
--- a/src/routes/coaching-sessions.ts
+++ b/src/routes/coaching-sessions.ts
@@ -7,16 +7,25 @@ const router = express.Router();
 
 const objectId = z.string().refine((val) => mongoose.Types.ObjectId.isValid(val), { message: 'Invalid id' });
 
-const createSchema = z.object({
+// Schema used for both creation and updates
+const baseSchema = z.object({
   name: z.string().min(1),
   coach: objectId.optional(),
   coachModel: z.enum(['Coach', 'User']).optional(),
   date: z.coerce.date()
-}).refine((data) => (!data.coach && !data.coachModel) || (data.coach && data.coachModel), {
+});
+
+// Helper to ensure coach and coachModel are provided together
+const together = (data: any) =>
+  (!data.coach && !data.coachModel) || (data.coach && data.coachModel);
+
+const createSchema = baseSchema.refine(together, {
   message: 'coach and coachModel must be provided together'
 });
 
-const updateSchema = createSchema.partial();
+const updateSchema = baseSchema.partial().refine(together, {
+  message: 'coach and coachModel must be provided together'
+});
 
 const listSchema = z.object({
   coach: objectId.optional(),


### PR DESCRIPTION
## Summary
- refactor schema logic to avoid TypeError when calling `.partial`
- ensure coach and coachModel fields are validated together in create and update routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0600ede60832d97036affc557b8c2