### PR TITLE
refactor: treat coaches as users

### DIFF
--- a/src/models/ClassSession.ts
+++ b/src/models/ClassSession.ts
@@ -22,10 +22,10 @@ const classSessionSchema = new Schema<IClassSession>({
     ref: 'ClassTemplate', 
     required: true 
   },
-  coachId: { 
-    type: Schema.Types.ObjectId, 
-    ref: 'Coach', 
-    required: true 
+  coachId: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
   },
   locationId: { type: String, required: true },
   room: { type: String, required: true, trim: true },

--- a/src/models/ClassTemplate.ts
+++ b/src/models/ClassTemplate.ts
@@ -30,9 +30,9 @@ const classTemplateSchema = new Schema<IClassTemplate>({
   durationMin: { type: Number, required: true, min: 15 },
   description: { type: String, required: true },
   gearNeeded: [{ type: String, trim: true }],
-  coachIds: [{ 
-    type: Schema.Types.ObjectId, 
-    ref: 'Coach' 
+  coachIds: [{
+    type: Schema.Types.ObjectId,
+    ref: 'User'
   }],
   price: { type: Number, min: 0 },
   prerequisites: [{ type: String, trim: true }]

--- a/src/models/Coach.ts
+++ b/src/models/Coach.ts
@@ -1,61 +1,8 @@
-import mongoose, { Schema, Document } from 'mongoose';
+import mongoose from 'mongoose';
+import { User, type IUser, type ISocialLink, type IAvailabilityRule } from './User';
 
-export interface ICoach extends Document {
-  name: string;
-  bio: string;
-  accolades: string[];
-  socials: ISocialLink[];
-  photo: string;
-  specialties: string[];
-  availabilityRules: IAvailabilityRule[];
-  hourlyRate?: number;
-  isActive: boolean;
-  createdAt: Date;
-  updatedAt: Date;
-}
+export interface ICoach extends IUser {}
 
-export interface ISocialLink {
-  platform: string;
-  url: string;
-}
+export const Coach = User as mongoose.Model<ICoach>;
 
-export interface IAvailabilityRule {
-  dayOfWeek: number; // 0-6
-  startTime: string; // HH:mm
-  endTime: string; // HH:mm
-  bufferMinutes: number;
-  leadTimeHours: number;
-}
-
-const socialLinkSchema = new Schema<ISocialLink>({
-  platform: { type: String, required: true },
-  url: { type: String, required: true }
-});
-
-const availabilityRuleSchema = new Schema<IAvailabilityRule>({
-  dayOfWeek: { type: Number, required: true, min: 0, max: 6 },
-  startTime: { type: String, required: true },
-  endTime: { type: String, required: true },
-  bufferMinutes: { type: Number, required: true, min: 0 },
-  leadTimeHours: { type: Number, required: true, min: 0 }
-});
-
-const coachSchema = new Schema<ICoach>({
-  name: { type: String, required: true, trim: true },
-  bio: { type: String, required: true },
-  accolades: [{ type: String }],
-  socials: [socialLinkSchema],
-  photo: { type: String, required: true },
-  specialties: [{ type: String, required: true }],
-  availabilityRules: [availabilityRuleSchema],
-  hourlyRate: { type: Number, min: 0 },
-  isActive: { type: Boolean, default: true }
-}, {
-  timestamps: true
-});
-
-// Indexes
-coachSchema.index({ isActive: 1 });
-coachSchema.index({ specialties: 1 });
-
-export const Coach = mongoose.model<ICoach>('Coach', coachSchema);
+export { ISocialLink, IAvailabilityRule };

--- a/src/models/CoachingSession.ts
+++ b/src/models/CoachingSession.ts
@@ -3,7 +3,6 @@ import mongoose, { Schema, Document } from 'mongoose';
 export interface ICoachingSession extends Document {
   name: string;
   coach?: mongoose.Types.ObjectId;
-  coachModel?: 'Coach' | 'User';
   date: Date;
   createdAt: Date;
   updatedAt: Date;
@@ -11,14 +10,7 @@ export interface ICoachingSession extends Document {
 
 const coachingSessionSchema = new Schema<ICoachingSession>({
   name: { type: String, required: true, trim: true },
-  coach: { type: Schema.Types.ObjectId, refPath: 'coachModel' },
-  coachModel: {
-    type: String,
-    enum: ['Coach', 'User'],
-    required: function(this: ICoachingSession) {
-      return !!this.coach;
-    }
-  },
+  coach: { type: Schema.Types.ObjectId, ref: 'User' },
   date: { type: Date, required: true }
 }, {
   timestamps: true

--- a/src/models/PrivateSession.ts
+++ b/src/models/PrivateSession.ts
@@ -20,10 +20,10 @@ const privateSessionSchema = new Schema<IPrivateSession>({
     ref: 'User', 
     required: true 
   },
-  coachId: { 
-    type: Schema.Types.ObjectId, 
-    ref: 'Coach', 
-    required: true 
+  coachId: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
   },
   startAt: { type: Date, required: true },
   endAt: { type: Date, required: true },

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,6 +1,19 @@
 import mongoose, { Schema, Document } from 'mongoose';
 import { UserRole, MembershipStatus } from '../types';
 
+export interface ISocialLink {
+  platform: string;
+  url: string;
+}
+
+export interface IAvailabilityRule {
+  dayOfWeek: number; // 0-6
+  startTime: string; // HH:mm
+  endTime: string; // HH:mm
+  bufferMinutes: number;
+  leadTimeHours: number;
+}
+
 export interface IUser extends Document {
   email: string;
   name: string;
@@ -10,6 +23,14 @@ export interface IUser extends Document {
   memberships: IMembership[];
   credits: number;
   defaultPaymentMethod?: string;
+  bio?: string;
+  accolades?: string[];
+  socials?: ISocialLink[];
+  photo?: string;
+  specialties?: string[];
+  availabilityRules?: IAvailabilityRule[];
+  hourlyRate?: number;
+  isActive?: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -36,6 +57,19 @@ const membershipSchema = new Schema<IMembership>({
   remainingClasses: { type: Number }
 });
 
+const socialLinkSchema = new Schema<ISocialLink>({
+  platform: { type: String, required: true },
+  url: { type: String, required: true }
+});
+
+const availabilityRuleSchema = new Schema<IAvailabilityRule>({
+  dayOfWeek: { type: Number, required: true, min: 0, max: 6 },
+  startTime: { type: String, required: true },
+  endTime: { type: String, required: true },
+  bufferMinutes: { type: Number, required: true, min: 0 },
+  leadTimeHours: { type: Number, required: true, min: 0 }
+});
+
 const userSchema = new Schema<IUser>({
   email: { 
     type: String, 
@@ -47,14 +81,22 @@ const userSchema = new Schema<IUser>({
   name: { type: String, required: true, trim: true },
   phone: { type: String, trim: true },
   passwordHash: { type: String, required: true },
-  roles: [{ 
-    type: String, 
+  roles: [{
+    type: String,
     enum: Object.values(UserRole),
     default: [UserRole.MEMBER]
   }],
   memberships: [membershipSchema],
   credits: { type: Number, default: 0, min: 0 },
-  defaultPaymentMethod: { type: String }
+  defaultPaymentMethod: { type: String },
+  bio: { type: String },
+  accolades: [{ type: String }],
+  socials: [socialLinkSchema],
+  photo: { type: String },
+  specialties: [{ type: String }],
+  availabilityRules: [availabilityRuleSchema],
+  hourlyRate: { type: Number, min: 0 },
+  isActive: { type: Boolean, default: true }
 }, {
   timestamps: true
 });
@@ -62,5 +104,6 @@ const userSchema = new Schema<IUser>({
 // Indexes
 userSchema.index({ email: 1 });
 userSchema.index({ roles: 1 });
+userSchema.index({ isActive: 1 });
 
 export const User = mongoose.model<IUser>('User', userSchema);

--- a/src/routes/coaching-sessions.ts
+++ b/src/routes/coaching-sessions.ts
@@ -8,24 +8,13 @@ const router = express.Router();
 const objectId = z.string().refine((val) => mongoose.Types.ObjectId.isValid(val), { message: 'Invalid id' });
 
 // Schema used for both creation and updates
-const baseSchema = z.object({
+const createSchema = z.object({
   name: z.string().min(1),
   coach: objectId.optional(),
-  coachModel: z.enum(['Coach', 'User']).optional(),
   date: z.coerce.date()
 });
 
-// Helper to ensure coach and coachModel are provided together
-const together = (data: any) =>
-  (!data.coach && !data.coachModel) || (data.coach && data.coachModel);
-
-const createSchema = baseSchema.refine(together, {
-  message: 'coach and coachModel must be provided together'
-});
-
-const updateSchema = baseSchema.partial().refine(together, {
-  message: 'coach and coachModel must be provided together'
-});
+const updateSchema = createSchema.partial();
 
 const listSchema = z.object({
   coach: objectId.optional(),

--- a/src/seeders/coachSeeder.ts
+++ b/src/seeders/coachSeeder.ts
@@ -1,16 +1,20 @@
+import bcrypt from 'bcryptjs';
 import { Coach } from '../models';
+import { UserRole } from '../types';
 import { coaches } from '../data/coaches';
 
 export const seedCoaches = async (): Promise<void> => {
   try {
     console.log('🌱 Seeding coaches...');
     
-    // Clear existing data
-    await Coach.deleteMany({});
+    // Clear existing coach data only
+    await Coach.deleteMany({ roles: UserRole.COACH });
     
     // Insert new data
-    const coachData = coaches.map(coach => ({
+    const coachData = await Promise.all(coaches.map(async (coach, index) => ({
+      email: `coach${index + 1}@example.com`,
       name: coach.name,
+      passwordHash: await bcrypt.hash('coach123', 10),
       bio: coach.bio,
       accolades: coach.accolades,
       socials: coach.socials,
@@ -18,8 +22,9 @@ export const seedCoaches = async (): Promise<void> => {
       specialties: coach.specialties,
       availabilityRules: coach.availabilityRules,
       hourlyRate: coach.hourlyRate,
-      isActive: coach.isActive
-    }));
+      isActive: coach.isActive,
+      roles: [UserRole.COACH]
+    })));
     
     await Coach.insertMany(coachData);
     

--- a/src/seeders/index.ts
+++ b/src/seeders/index.ts
@@ -15,12 +15,12 @@ export const runAllSeeders = async (): Promise<void> => {
     
     // Run seeders in dependency order
     await seedDisciplines();
+    await seedUsers();
     await seedCoaches();
     await seedTemplates(); // Depends on disciplines and coaches
     await seedProducts();
     await seedContent();
     await seedMembershipPlans();
-    await seedUsers();
     
     console.log('🎉 All seeders completed successfully!');
   } catch (error) {

--- a/src/seeders/templateSeeder.ts
+++ b/src/seeders/templateSeeder.ts
@@ -1,4 +1,5 @@
 import { ClassTemplate, ClassDiscipline, Coach } from '../models';
+import { UserRole } from '../types';
 import { templates } from '../data/templates';
 
 export const seedTemplates = async (): Promise<void> => {
@@ -10,7 +11,7 @@ export const seedTemplates = async (): Promise<void> => {
     
     // Get discipline and coach mappings
     const disciplines = await ClassDiscipline.find({});
-    const coaches = await Coach.find({});
+    const coaches = await Coach.find({ roles: UserRole.COACH });
     
     const disciplineMap = new Map(disciplines.map(d => [d.slug, d._id]));
     const coachMap = new Map(coaches.map(c => [c.name, c._id]));

--- a/src/seeders/userSeeder.ts
+++ b/src/seeders/userSeeder.ts
@@ -27,14 +27,6 @@ export const seedUsers = async (): Promise<void> => {
         roles: [UserRole.MEMBER],
         memberships: [],
         credits: 10
-      },
-      {
-        email: 'coach@tigermuaythailb.com',
-        name: 'Coach Demo',
-        passwordHash: await bcrypt.hash('coach123', 10),
-        roles: [UserRole.COACH],
-        memberships: [],
-        credits: 0
       }
     ];
     


### PR DESCRIPTION
## Summary
- unifies coaches under User schema with role-based filtering
- updates coach service, session models, and seeders to reference User
- simplifies coaching session routes to drop dynamic coach model references

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c06bd7b2dc832db0ec79c74e17f79c