### PR TITLE
Replace availability rules with booked sessions

### DIFF
--- a/src/data/coaches.ts
+++ b/src/data/coaches.ts
@@ -1,12 +1,16 @@
-import { AvailabilityRule, Coach } from '../types';
+import { Coach, SessionRepetition } from '../types';
 
-const defaultAvailability: AvailabilityRule[] = [
-  { dayOfWeek: 1, startTime: '06:00', endTime: '21:00', bufferMinutes: 30, leadTimeHours: 24 },
-  { dayOfWeek: 2, startTime: '06:00', endTime: '21:00', bufferMinutes: 30, leadTimeHours: 24 },
-  { dayOfWeek: 3, startTime: '06:00', endTime: '21:00', bufferMinutes: 30, leadTimeHours: 24 },
-  { dayOfWeek: 4, startTime: '06:00', endTime: '21:00', bufferMinutes: 30, leadTimeHours: 24 },
-  { dayOfWeek: 5, startTime: '06:00', endTime: '21:00', bufferMinutes: 30, leadTimeHours: 24 },
-  { dayOfWeek: 6, startTime: '08:00', endTime: '18:00', bufferMinutes: 30, leadTimeHours: 24 },
+const defaultBookedSessions: Coach['bookedSessions'] = [
+  {
+    templateId: 'tmpl-bjj-101',
+    sessionDate: new Date('2024-08-05T10:00:00.000Z'),
+    repetition: SessionRepetition.WEEKLY,
+  },
+  {
+    name: 'Competition Prep: No-Gi Drilling',
+    sessionDate: new Date('2024-08-07T18:00:00.000Z'),
+    repetition: SessionRepetition.DAILY,
+  },
 ];
 
 export const coaches: Coach[] = [
@@ -24,7 +28,7 @@ export const coaches: Coach[] = [
     ],
     photo: 'https://images.pexels.com/photos/1043471/pexels-photo-1043471.jpeg',
     specialties: ['Brazilian Jiu-Jitsu', 'No-Gi Grappling', 'Competition Training'],
-    availabilityRules: defaultAvailability,
+    bookedSessions: defaultBookedSessions,
     hourlyRate: 120,
     isActive: true,
   },
@@ -42,7 +46,18 @@ export const coaches: Coach[] = [
     ],
     photo: 'https://images.pexels.com/photos/1681010/pexels-photo-1681010.jpeg',
     specialties: ['Muay Thai', 'Traditional Thai Boxing', 'Clinch Work'],
-    availabilityRules: defaultAvailability,
+    bookedSessions: [
+      {
+        templateId: 'tmpl-muaythai-advanced',
+        sessionDate: new Date('2024-08-06T16:00:00.000Z'),
+        repetition: SessionRepetition.WEEKLY,
+      },
+      {
+        name: 'Private Elbow Workshop',
+        sessionDate: new Date('2024-08-09T14:00:00.000Z'),
+        repetition: SessionRepetition.MONTHLY,
+      },
+    ],
     hourlyRate: 100,
     isActive: true,
   },
@@ -60,7 +75,18 @@ export const coaches: Coach[] = [
     ],
     photo: 'https://images.pexels.com/photos/1153867/pexels-photo-1153867.jpeg',
     specialties: ['Boxing', 'Footwork', 'Ring Strategy'],
-    availabilityRules: defaultAvailability,
+    bookedSessions: [
+      {
+        templateId: 'tmpl-boxing-201',
+        sessionDate: new Date('2024-08-08T12:00:00.000Z'),
+        repetition: SessionRepetition.WEEKLY,
+      },
+      {
+        name: 'Youth Sparring Camp',
+        sessionDate: new Date('2024-08-15T20:00:00.000Z'),
+        repetition: SessionRepetition.MONTHLY,
+      },
+    ],
     hourlyRate: 90,
     isActive: true,
   },
@@ -78,7 +104,18 @@ export const coaches: Coach[] = [
     ],
     photo: 'https://images.pexels.com/photos/1181686/pexels-photo-1181686.jpeg',
     specialties: ['MMA', 'Women\'s Self-Defense', 'Cage Work'],
-    availabilityRules: defaultAvailability,
+    bookedSessions: [
+      {
+        templateId: 'tmpl-mma-conditioning',
+        sessionDate: new Date('2024-08-10T09:00:00.000Z'),
+        repetition: SessionRepetition.WEEKLY,
+      },
+      {
+        name: 'Octagon Strategy Breakdown',
+        sessionDate: new Date('2024-08-18T17:00:00.000Z'),
+        repetition: SessionRepetition.MONTHLY,
+      },
+    ],
     hourlyRate: 140,
     isActive: true,
   },
@@ -96,7 +133,18 @@ export const coaches: Coach[] = [
     ],
     photo: 'https://images.pexels.com/photos/1581384/pexels-photo-1581384.jpeg',
     specialties: ['Wrestling', 'Takedowns', 'Ground Control'],
-    availabilityRules: defaultAvailability,
+    bookedSessions: [
+      {
+        templateId: 'tmpl-wrestling-takedowns',
+        sessionDate: new Date('2024-08-03T11:00:00.000Z'),
+        repetition: SessionRepetition.WEEKLY,
+      },
+      {
+        name: 'Chain Wrestling Intensive',
+        sessionDate: new Date('2024-08-20T19:00:00.000Z'),
+        repetition: SessionRepetition.MONTHLY,
+      },
+    ],
     hourlyRate: 110,
     isActive: true,
   }

--- a/src/models/Coach.ts
+++ b/src/models/Coach.ts
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-import { User, type IUser, type ISocialLink, type IAvailabilityRule } from './User';
+import { User, type IUser, type ISocialLink, type IBookedSession } from './User';
 
 export interface ICoach extends IUser {
     password: string; // Plain text password for creation only
@@ -7,4 +7,4 @@ export interface ICoach extends IUser {
 
 export const Coach = User as mongoose.Model<ICoach>;
 
-export { ISocialLink, IAvailabilityRule };
+export { ISocialLink, IBookedSession };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -2,7 +2,7 @@
 export { ClassDiscipline, type IClassDiscipline, type IMediaItem } from './ClassDiscipline';
 export { ClassSession, type IClassSession } from './ClassSession';
 export { ClassTemplate, type IClassTemplate } from './ClassTemplate';
-export { Coach, type IAvailabilityRule, type ICoach, type ISocialLink } from './Coach';
+export { Coach, type IBookedSession, type ICoach, type ISocialLink } from './Coach';
 export { CoachingSession, type ICoachingSession } from './CoachingSession';
 export { ContentBlock, type IContentBlock } from './ContentBlock';
 export { MembershipPlan, type IMembershipPlan } from './MembershipPlan';

--- a/src/routes/coaches.ts
+++ b/src/routes/coaches.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { CoachService } from '../services/coachService';
 import { ApiResponse } from '../types';
+import { IBookedSession } from '../models';
 import { requireAdmin } from '../middleware/requireAdmin';
 
 const router = express.Router();
@@ -113,24 +114,20 @@ router.delete('/:id', requireAdmin, async (req, res) => {
   }
 });
 
-// GET /api/coaches/:id/availability
-router.get('/:id/availability', async (req, res) => {
+// GET /api/coaches/:id/booked-sessions
+router.get('/:id/booked-sessions', async (req, res) => {
   const { id } = req.params;
-  const { from, to } = req.query;
-  
+
   try {
-    const fromDate = new Date(from as string || new Date());
-    const toDate = new Date(to as string || new Date(Date.now() + 7 * 24 * 60 * 60 * 1000));
-    
-    const availableSlots = await CoachService.getCoachAvailability(id, fromDate, toDate);
-    
-    const response: ApiResponse<any> = {
-      data: availableSlots,
+    const bookedSessions = await CoachService.getCoachBookedSessions(id);
+
+    const response: ApiResponse<IBookedSession[]> = {
+      data: bookedSessions,
     };
-    
+
     res.json(response);
   } catch (error) {
-    console.error('Error fetching coach availability:', error);
+    console.error('Error fetching coach booked sessions:', error);
     if (error instanceof Error && error.message === 'Coach not found') {
       return res.status(404).json({
         error: 'Coach Not Found',
@@ -139,7 +136,7 @@ router.get('/:id/availability', async (req, res) => {
     }
     res.status(500).json({
       error: 'Internal Server Error',
-      message: 'Failed to fetch coach availability'
+      message: 'Failed to fetch coach booked sessions'
     });
   }
 });

--- a/src/seeders/coachSeeder.ts
+++ b/src/seeders/coachSeeder.ts
@@ -20,7 +20,7 @@ export const seedCoaches = async (): Promise<void> => {
       socials: coach.socials,
       photo: coach.photo,
       specialties: coach.specialties,
-      availabilityRules: coach.availabilityRules,
+      bookedSessions: coach.bookedSessions,
       hourlyRate: coach.hourlyRate,
       isActive: coach.isActive,
       roles: [UserRole.COACH]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,24 @@ export enum SessionStatus {
   COMPLETED = 'completed',
 }
 
+export interface SocialLink {
+  platform: string;
+  url: string;
+}
+
+export enum SessionRepetition {
+  DAILY = 'daily',
+  WEEKLY = 'weekly',
+  MONTHLY = 'monthly',
+}
+
+export interface BookedSession {
+  sessionDate: Date;
+  repetition: SessionRepetition;
+  templateId?: string;
+  name?: string;
+}
+
 export interface Coach {
   id: string;
   name: string;
@@ -77,22 +95,9 @@ export interface Coach {
   socials: SocialLink[];
   photo: string;
   specialties: string[];
-  availabilityRules: AvailabilityRule[];
+  bookedSessions: BookedSession[];
   hourlyRate?: number;
   isActive: boolean;
-}
-
-export interface SocialLink {
-  platform: string;
-  url: string;
-}
-
-export interface AvailabilityRule {
-  dayOfWeek: number; // 0-6
-  startTime: string; // HH:mm
-  endTime: string; // HH:mm
-  bufferMinutes: number;
-  leadTimeHours: number;
 }
 
 export interface MembershipPlan {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -21,7 +21,7 @@ tags:
   - name: Classes
     description: Class schedules and templates
   - name: Coaches
-    description: Coach profiles and availability
+    description: Coach profiles and booked sessions
   - name: Auth
     description: Authentication and authorization
   - name: Shop
@@ -435,33 +435,28 @@ paths:
         '404':
           description: Coach not found
 
-  /coaches/{id}/availability:
+  /coaches/{id}/booked-sessions:
     get:
       tags: [Coaches]
-      summary: Get coach availability
+      summary: Get coach booked sessions
       parameters:
         - in: path
           name: id
           required: true
           schema:
             type: string
-        - in: query
-          name: from
-          schema:
-            type: string
-            format: date-time
-        - in: query
-          name: to
-          schema:
-            type: string
-            format: date-time
       responses:
         '200':
-          description: Available time slots
+          description: Booked sessions for the coach
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse'
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/BookedSession'
         '404':
           description: Coach not found
 
@@ -1007,6 +1002,10 @@ components:
           type: array
           items:
             type: string
+        bookedSessions:
+          type: array
+          items:
+            $ref: '#/components/schemas/BookedSession'
         hourlyRate:
           type: number
           minimum: 0
@@ -1059,6 +1058,21 @@ components:
         url:
           type: string
           format: uri
+
+    BookedSession:
+      type: object
+      required: [sessionDate, repetition]
+      properties:
+        templateId:
+          type: string
+        name:
+          type: string
+        sessionDate:
+          type: string
+          format: date-time
+        repetition:
+          type: string
+          enum: [daily, weekly, monthly]
 
   securitySchemes:
     bearerAuth:


### PR DESCRIPTION
## Summary
- replace coach availability rules with booked sessions on the user model, including schema validation and repetition enum
- update coach services, routes, and seed data to consume the new booked session structure
- refresh type definitions and API documentation to describe booked session data and the new booked-sessions endpoint

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d188a16744832d8b542f9c000f7d66