### PR TITLE
docs: regenerate swagger spec

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,867 +1,156 @@
-openapi: 3.1.0
+openapi: 3.0.3
 info:
-  title: MMA Gym API
-  description: Complete API for managing MMA gym operations including classes, bookings, shop, and user management
+  title: Tiger API
+  description: |
+    REST API for the Tiger training platform. All responses are wrapped in the
+    `ApiResponse` envelope unless otherwise noted.
   version: 1.0.0
-  contact:
-    name: Apex MMA
-    email: dev@apexmma.com
-
 servers:
-  - url: http://localhost:3001/api
-    description: Development server
-  - url: http://localhost:3001
-    description: Development root
-  - url: https://api.apexmma.com
+  - url: https://localhost:3001
+    description: Local development server
+  - url: https://api.tiger.example.com
     description: Production server
-
-tags:
-  - name: Content
-    description: CMS content management
-  - name: Classes
-    description: Class schedules and templates
-  - name: Coaches
-    description: Coach profiles and booked sessions
-  - name: Auth
-    description: Authentication and authorization
-  - name: Shop
-    description: E-commerce operations
-  - name: User
-    description: User profile and account management
-  - name: Bookings
-    description: Class and session bookings
-  - name: Membership Plans
-    description: Membership plan management
-  - name: Private Sessions
-    description: Personal training sessions
-  - name: Webhooks
-    description: External service webhooks
-  - name: Health
-    description: Service health checks
-  - name: Admin
-    description: Administrative endpoints
-
-paths:
-  /admin/content:
-    get:
-      tags: [Admin]
-      summary: List all content blocks
-      parameters:
-        - in: query
-          name: locale
-          schema:
-            type: string
-            default: en
-      responses:
-        '200':
-          description: List of content blocks
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ContentBlock'
-
-  /admin/disciplines:
-    get:
-      tags: [Admin]
-      summary: List all disciplines
-      responses:
-        '200':
-          description: List of disciplines
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ClassDiscipline'
-
-  /admin/class-templates:
-    get:
-      tags: [Admin]
-      summary: List all class templates
-      responses:
-        '200':
-          description: List of class templates
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ClassTemplate'
-
-  /admin/class-sessions:
-    get:
-      tags: [Admin]
-      summary: List all class sessions
-      responses:
-        '200':
-          description: List of class sessions
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ClassSession'
-
-  /admin/product-categories:
-    get:
-      tags: [Admin]
-      summary: List product categories
-      responses:
-        '200':
-          description: List of product categories
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ProductCategory'
-
-  /content/{key}:
-    get:
-      tags: [Content]
-      summary: Get content block by key
-      parameters:
-        - in: path
-          name: key
-          required: true
-          schema:
-            type: string
-          example: "home.hero"
-        - in: query
-          name: locale
-          schema:
-            type: string
-            default: en
-      responses:
-        '200':
-          description: Content block retrieved successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-    put:
-      tags: [Content]
-      summary: Update content block
-      security:
-        - bearerAuth: []
-      parameters:
-        - in: path
-          name: key
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [locale, json]
-              properties:
-                locale:
-                  type: string
-                  default: en
-                json:
-                  type: object
-      responses:
-        '200':
-          description: Content block updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-    delete:
-      tags: [Content]
-      summary: Delete content block
-      security:
-        - bearerAuth: []
-      parameters:
-        - in: path
-          name: key
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: locale
-          schema:
-            type: string
-            default: en
-      responses:
-        '200':
-          description: Content block deleted
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-        '404':
-          description: Content block not found
-
-  /classes/disciplines:
-    get:
-      tags: [Classes]
-      summary: List all martial arts disciplines
-      responses:
-        '200':
-          description: List of disciplines
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ClassDiscipline'
-
-  /classes/templates:
-    get:
-      tags: [Classes]
-      summary: List class templates with filters
-      parameters:
-        - in: query
-          name: discipline
-          schema:
-            type: string
-        - in: query
-          name: level
-          schema:
-            type: string
-        - in: query
-          name: coachId
-          schema:
-            type: string
-      responses:
-        '200':
-          description: List of class templates
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ClassTemplate'
-
-  /classes/templates/{id}:
-    get:
-      tags: [Classes]
-      summary: Get class template by ID
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Class template details
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ClassTemplate'
-        '404':
-          description: Class template not found
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                  message:
-                    type: string
-
-  /classes/sessions:
-    get:
-      tags: [Classes]
-      summary: List class sessions with filters
-      parameters:
-        - in: query
-          name: from
-          schema:
-            type: string
-            format: date-time
-        - in: query
-          name: to
-          schema:
-            type: string
-            format: date-time
-        - in: query
-          name: discipline
-          schema:
-            type: string
-        - in: query
-          name: coachId
-          schema:
-            type: string
-      responses:
-        '200':
-          description: List of class sessions
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ClassSession'
-
-  /coaches:
-    get:
-      tags: [Coaches]
-      summary: List all active coaches
-      parameters:
-        - in: query
-          name: specialty
-          schema:
-            type: string
-      responses:
-        '200':
-          description: List of coaches
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Coach'
-
-  /auth/login:
-    post:
-      tags: [Auth]
-      summary: User authentication
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [email, password]
-              properties:
-                email:
-                  type: string
-                  format: email
-                password:
-                  type: string
-                  minLength: 6
-      responses:
-        '200':
-          description: Login successful
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      token:
-                        type: string
-                      user:
-                        $ref: '#/components/schemas/User'
-  /auth/register:
-    post:
-      tags: [Auth]
-      summary: Register a new user
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [email, password, name]
-              properties:
-                email:
-                  type: string
-                  format: email
-                password:
-                  type: string
-                name:
-                  type: string
-                phone:
-                  type: string
-      responses:
-        '201':
-          description: User registered successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-
-  /coaches/{id}:
-    get:
-      tags: [Coaches]
-      summary: Get coach by ID
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Coach details
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Coach'
-        '404':
-          description: Coach not found
-
-  /coaches/{id}/booked-sessions:
-    get:
-      tags: [Coaches]
-      summary: Get coach booked sessions
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Booked sessions for the coach
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/BookedSession'
-        '404':
-          description: Coach not found
-
-  /bookings:
-    post:
-      tags: [Bookings]
-      summary: Create a booking
-      security:
-        - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [userId, sessionId]
-              properties:
-                userId:
-                  type: string
-                sessionId:
-                  type: string
-      responses:
-        '201':
-          description: Booking created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-
-  /bookings/{id}:
-    delete:
-      tags: [Bookings]
-      summary: Cancel a booking
-      security:
-        - bearerAuth: []
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Booking cancelled
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-        '404':
-          description: Booking not found
-
-  /membership-plans:
-    get:
-      tags: [Membership Plans]
-      summary: List membership plans
-      responses:
-        '200':
-          description: List of plans
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-    post:
-      tags: [Membership Plans]
-      summary: Create a membership plan
-      security:
-        - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        '201':
-          description: Plan created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-
-  /membership-plans/{id}:
-    get:
-      tags: [Membership Plans]
-      summary: Get membership plan
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Plan details
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-        '404':
-          description: Plan not found
-    put:
-      tags: [Membership Plans]
-      summary: Update membership plan
-      security:
-        - bearerAuth: []
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        '200':
-          description: Plan updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-        '404':
-          description: Plan not found
-    delete:
-      tags: [Membership Plans]
-      summary: Delete membership plan
-      security:
-        - bearerAuth: []
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Plan deleted
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-        '404':
-          description: Plan not found
-
-  /private-sessions:
-    post:
-      tags: [Private Sessions]
-      summary: Book a private session
-      security:
-        - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [userId, coachId, startAt, endAt]
-              properties:
-                userId:
-                  type: string
-                coachId:
-                  type: string
-                startAt:
-                  type: string
-                  format: date-time
-                endAt:
-                  type: string
-                  format: date-time
-                notes:
-                  type: string
-      responses:
-        '201':
-          description: Private session booked
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-
-  /private-sessions/{id}/cancel:
-    post:
-      tags: [Private Sessions]
-      summary: Cancel a private session
-      security:
-        - bearerAuth: []
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Session cancelled
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-        '404':
-          description: Session not found
-
-  /shop/categories:
-    get:
-      tags: [Shop]
-      summary: List product categories
-      responses:
-        '200':
-          description: Category list
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-
-  /shop/products:
-    get:
-      tags: [Shop]
-      summary: List products with filters
-      parameters:
-        - in: query
-          name: query
-          schema:
-            type: string
-        - in: query
-          name: categoryId
-          schema:
-            type: string
-        - in: query
-          name: inStock
-          schema:
-            type: boolean
-        - in: query
-          name: sort
-          schema:
-            type: string
-        - in: query
-          name: page
-          schema:
-            type: integer
-        - in: query
-          name: limit
-          schema:
-            type: integer
-      responses:
-        '200':
-          description: Product list
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-
-  /shop/products/{id}:
-    get:
-      tags: [Shop]
-      summary: Get product by ID
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Product details
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-        '404':
-          description: Product not found
-
-  /shop/cart:
-    post:
-      tags: [Shop]
-      summary: Calculate cart totals
-      security:
-        - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        '200':
-          description: Cart calculated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-
-  /shop/whatsapp-config:
-    get:
-      tags: [Shop]
-      summary: Get WhatsApp order configuration
-      responses:
-        '200':
-          description: Configuration data
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-
-  /me:
-    get:
-      tags: [User]
-      summary: Get current user profile
-      security:
-        - bearerAuth: []
-      responses:
-        '200':
-          description: User profile
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-
-  /me/bookings:
-    get:
-      tags: [User]
-      summary: Get current user's bookings
-      security:
-        - bearerAuth: []
-      responses:
-        '200':
-          description: Booking list
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-
-  /me/orders:
-    get:
-      tags: [User]
-      summary: Get current user's orders
-      security:
-        - bearerAuth: []
-      responses:
-        '200':
-          description: Order list
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-
-  /webhooks/stripe:
-    post:
-      tags: [Webhooks]
-      summary: Handle Stripe webhooks
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        '200':
-          description: Webhook received
-
-  /health:
-    get:
-      tags: [Health]
-      summary: Health check
-      responses:
-        '200':
-          description: Service status
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                  timestamp:
-                    type: string
-                    format: date-time
-
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     ApiResponse:
       type: object
       properties:
         data:
-          oneOf:
-            - type: object
-            - type: array
+          description: Wrapped payload.
         meta:
           type: object
           properties:
             page:
               type: integer
+              minimum: 1
             limit:
               type: integer
+              minimum: 1
             total:
               type: integer
+              minimum: 0
             totalPages:
               type: integer
-
-    ClassDiscipline:
+              minimum: 0
+    PaginationMeta:
       type: object
-      required: [id, name, slug]
+      properties:
+        page:
+          type: integer
+          minimum: 1
+        limit:
+          type: integer
+          minimum: 1
+        total:
+          type: integer
+          minimum: 0
+        totalPages:
+          type: integer
+          minimum: 0
+    ApiError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+        message:
+          type: string
+    Address:
+      type: object
+      required:
+        - line1
+        - city
+        - state
+        - postalCode
+        - country
+      properties:
+        line1:
+          type: string
+        line2:
+          type: string
+        city:
+          type: string
+        state:
+          type: string
+        postalCode:
+          type: string
+        country:
+          type: string
+    MediaItem:
+      type: object
+      required:
+        - type
+        - src
+      properties:
+        type:
+          type: string
+          enum: [image, video]
+        src:
+          type: string
+          format: uri
+        alt:
+          type: string
+        caption:
+          type: string
+    SocialLink:
+      type: object
+      required:
+        - platform
+        - url
+      properties:
+        platform:
+          type: string
+        url:
+          type: string
+          format: uri
+    ContentBlock:
+      type: object
+      required:
+        - id
+        - key
+        - locale
+        - json
+        - createdAt
+        - updatedAt
       properties:
         id:
           type: string
+          readOnly: true
+        key:
+          type: string
+        locale:
+          type: string
+        json:
+          description: Arbitrary JSON payload rendered for the content block.
+          type: object
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          readOnly: true
+    ClassDiscipline:
+      type: object
+      required:
+        - id
+        - slug
+        - name
+        - description
+        - tags
+        - media
+      properties:
+        id:
+          type: string
+          readOnly: true
         slug:
           type: string
         name:
@@ -876,13 +165,21 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/MediaItem'
-
     ClassTemplate:
       type: object
-      required: [id, disciplineId, title, level, durationMin, description]
+      required:
+        - id
+        - disciplineId
+        - title
+        - level
+        - durationMin
+        - description
+        - gearNeeded
+        - coachIds
       properties:
         id:
           type: string
+          readOnly: true
         disciplineId:
           type: string
         title:
@@ -908,78 +205,34 @@ components:
           type: array
           items:
             type: string
-
-    ClassSession:
+    BookedSession:
       type: object
-      required: [id, templateId, coachId, startAt, endAt]
+      required:
+        - sessionDate
+        - repetition
       properties:
-        id:
-          type: string
         templateId:
-          type: string
-        coachId:
-          type: string
-        locationId:
-          type: string
-        room:
-          type: string
-        startAt:
-          type: string
-          format: date-time
-        endAt:
-          type: string
-          format: date-time
-        capacity:
-          type: integer
-          minimum: 1
-        bookedCount:
-          type: integer
-          minimum: 0
-        waitlist:
-          type: array
-          items:
-            type: string
-        status:
-          type: string
-          enum: [scheduled, cancelled, full, in_progress, completed]
-
-    ContentBlock:
-      type: object
-      required: [id, key, locale, json]
-      properties:
-        id:
-          type: string
-        key:
-          type: string
-        locale:
-          type: string
-        json:
-          type: object
-        createdAt:
-          type: string
-          format: date-time
-        updatedAt:
-          type: string
-          format: date-time
-
-    ProductCategory:
-      type: object
-      required: [id, name, slug]
-      properties:
-        id:
           type: string
         name:
           type: string
-        slug:
+        sessionDate:
           type: string
-        description:
+          format: date-time
+        repetition:
           type: string
-        parentId:
-          type: string
-
+          enum: [daily, weekly, monthly]
     Coach:
       type: object
-      required: [id, name]
+      required:
+        - id
+        - name
+        - bio
+        - accolades
+        - socials
+        - photo
+        - specialties
+        - bookedSessions
+        - isActive
       properties:
         id:
           type: string
@@ -1008,16 +261,268 @@ components:
             $ref: '#/components/schemas/BookedSession'
         hourlyRate:
           type: number
-          minimum: 0
         isActive:
           type: boolean
-
-    User:
+    MembershipPlan:
       type: object
-      required: [id, email, name]
+      required:
+        - id
+        - name
+        - price
+        - currency
+        - period
+        - benefits
+        - classAccess
+        - terms
       properties:
         id:
           type: string
+          readOnly: true
+        name:
+          type: string
+        price:
+          type: number
+        currency:
+          type: string
+        period:
+          type: string
+          enum: [monthly, quarterly, yearly]
+        benefits:
+          type: array
+          items:
+            type: string
+        maxClassesPerPeriod:
+          type: integer
+        classAccess:
+          type: array
+          items:
+            type: string
+        terms:
+          type: string
+        isPopular:
+          type: boolean
+    ProductVariant:
+      type: object
+      required:
+        - id
+        - name
+        - price
+        - stock
+        - attributes
+      properties:
+        id:
+          type: string
+          readOnly: true
+        name:
+          type: string
+        price:
+          type: number
+        stock:
+          type: integer
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+    ProductAttribute:
+      type: object
+      required:
+        - key
+        - value
+      properties:
+        key:
+          type: string
+        value:
+          type: string
+    Product:
+      type: object
+      required:
+        - id
+        - sku
+        - title
+        - description
+        - categoryId
+        - images
+        - variants
+        - price
+        - stock
+        - attributes
+        - isActive
+      properties:
+        id:
+          type: string
+          readOnly: true
+        sku:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        categoryId:
+          type: string
+        images:
+          type: array
+          items:
+            type: string
+            format: uri
+        variants:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProductVariant'
+        price:
+          type: number
+        compareAtPrice:
+          type: number
+        stock:
+          type: integer
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProductAttribute'
+        isActive:
+          type: boolean
+    ProductCategory:
+      type: object
+      required:
+        - id
+        - name
+        - slug
+      properties:
+        id:
+          type: string
+          readOnly: true
+        name:
+          type: string
+        slug:
+          type: string
+        description:
+          type: string
+        parentId:
+          type: string
+    CartItem:
+      type: object
+      required:
+        - productId
+        - quantity
+        - price
+      properties:
+        productId:
+          type: string
+        variantId:
+          type: string
+        quantity:
+          type: integer
+          minimum: 1
+        price:
+          type: number
+    Cart:
+      type: object
+      required:
+        - id
+        - userId
+        - items
+        - subtotal
+        - tax
+        - total
+        - createdAt
+      properties:
+        id:
+          type: string
+          readOnly: true
+        userId:
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/CartItem'
+        subtotal:
+          type: number
+          readOnly: true
+        tax:
+          type: number
+          readOnly: true
+        total:
+          type: number
+          readOnly: true
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+    OrderItem:
+      type: object
+      required:
+        - productId
+        - quantity
+        - price
+        - title
+      properties:
+        productId:
+          type: string
+        variantId:
+          type: string
+        quantity:
+          type: integer
+        price:
+          type: number
+        title:
+          type: string
+    Order:
+      type: object
+      required:
+        - id
+        - total
+        - status
+        - createdAt
+        - items
+      properties:
+        id:
+          type: string
+          readOnly: true
+        userId:
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderItem'
+        subtotal:
+          type: number
+          readOnly: true
+        tax:
+          type: number
+          readOnly: true
+        shipping:
+          type: number
+          readOnly: true
+        total:
+          type: number
+          readOnly: true
+        status:
+          type: string
+          enum: [pending, paid, shipped, delivered, cancelled, refunded]
+        paymentIntentId:
+          type: string
+        shippingAddress:
+          $ref: '#/components/schemas/Address'
+        billingAddress:
+          $ref: '#/components/schemas/Address'
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+    User:
+      type: object
+      required:
+        - id
+        - email
+        - name
+        - roles
+        - memberships
+        - credits
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          readOnly: true
         email:
           type: string
           format: email
@@ -1030,55 +535,1438 @@ components:
           items:
             type: string
             enum: [guest, member, coach, admin]
+        memberships:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                readOnly: true
+              planId:
+                type: string
+              status:
+                type: string
+              startDate:
+                type: string
+                format: date-time
+              endDate:
+                type: string
+                format: date-time
+              remainingClasses:
+                type: integer
         credits:
           type: integer
-          minimum: 0
-
-    MediaItem:
-      type: object
-      required: [type, src]
-      properties:
-        type:
+        defaultPaymentMethod:
           type: string
-          enum: [image, video]
-        src:
-          type: string
-          format: uri
-        alt:
-          type: string
-        caption:
-          type: string
-
-    SocialLink:
-      type: object
-      required: [platform, url]
-      properties:
-        platform:
-          type: string
-        url:
-          type: string
-          format: uri
-
-    BookedSession:
-      type: object
-      required: [sessionDate, repetition]
-      properties:
-        templateId:
-          type: string
-        name:
-          type: string
-        sessionDate:
+        createdAt:
           type: string
           format: date-time
-        repetition:
+          readOnly: true
+        updatedAt:
           type: string
-          enum: [daily, weekly, monthly]
-
-  securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
-
-security:
-  - bearerAuth: []
+          format: date-time
+          readOnly: true
+paths:
+  /health:
+    get:
+      tags: [System]
+      summary: Health check
+      operationId: getHealth
+      responses:
+        '200':
+          description: API is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  timestamp:
+                    type: string
+                    format: date-time
+  /api/auth/login:
+    post:
+      tags: [Auth]
+      summary: Authenticate a user
+      operationId: login
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, password]
+              properties:
+                email:
+                  type: string
+                  format: email
+                password:
+                  type: string
+      responses:
+        '200':
+          description: Login succeeded
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          token:
+                            type: string
+                          user:
+                            $ref: '#/components/schemas/User'
+        '400':
+          description: Missing credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '401':
+          description: Invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Authentication error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/auth/register:
+    post:
+      tags: [Auth]
+      summary: Register a new member account
+      operationId: register
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, password, name]
+              properties:
+                email:
+                  type: string
+                  format: email
+                password:
+                  type: string
+                name:
+                  type: string
+                phone:
+                  type: string
+      responses:
+        '201':
+          description: Registration succeeded
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          token:
+                            type: string
+                          user:
+                            $ref: '#/components/schemas/User'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '409':
+          description: User already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Registration failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/content/{key}:
+    parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+        description: Content key identifier
+    get:
+      tags: [Content]
+      summary: Retrieve a content block by key
+      operationId: getContentByKey
+      parameters:
+        - in: query
+          name: locale
+          schema:
+            type: string
+            default: en
+      responses:
+        '200':
+          description: Content block JSON
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        description: Localized JSON content
+        '404':
+          description: Content block not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    put:
+      tags: [Content]
+      summary: Create or update a content block
+      operationId: updateContent
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [json]
+              properties:
+                locale:
+                  type: string
+                  default: en
+                json:
+                  description: Arbitrary JSON payload to persist
+                  type: object
+      responses:
+        '200':
+          description: Content block saved
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ContentBlock'
+        '400':
+          description: Missing JSON payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Save error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    delete:
+      tags: [Content]
+      summary: Delete a localized content block
+      operationId: deleteContent
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: locale
+          schema:
+            type: string
+            default: en
+      responses:
+        '200':
+          description: Content block deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ContentBlock'
+        '404':
+          description: Content block not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Deletion error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/admin/content:
+    get:
+      tags: [Admin]
+      summary: List all content blocks for a locale
+      operationId: adminListContent
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: locale
+          schema:
+            type: string
+            default: en
+      responses:
+        '200':
+          description: Content blocks
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ContentBlock'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/admin/disciplines:
+    get:
+      tags: [Admin]
+      summary: List all class disciplines
+      operationId: adminListDisciplines
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Disciplines
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ClassDiscipline'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/admin/class-templates:
+    get:
+      tags: [Admin]
+      summary: List all class templates
+      operationId: adminListClassTemplates
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Class templates
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ClassTemplate'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/admin/product-categories:
+    get:
+      tags: [Admin]
+      summary: List product categories
+      operationId: adminListProductCategories
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Product categories
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ProductCategory'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/classes/disciplines:
+    get:
+      tags: [Classes]
+      summary: List class disciplines
+      operationId: listDisciplines
+      responses:
+        '200':
+          description: Disciplines
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ClassDiscipline'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    post:
+      tags: [Classes]
+      summary: Create a class discipline
+      operationId: createDiscipline
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClassDiscipline'
+      responses:
+        '201':
+          description: Discipline created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ClassDiscipline'
+        '500':
+          description: Creation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/classes/disciplines/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    put:
+      tags: [Classes]
+      summary: Update a class discipline
+      operationId: updateDiscipline
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClassDiscipline'
+      responses:
+        '200':
+          description: Discipline updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ClassDiscipline'
+        '404':
+          description: Discipline not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Update error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    delete:
+      tags: [Classes]
+      summary: Delete a class discipline
+      operationId: deleteDiscipline
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Discipline deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          success:
+                            type: boolean
+        '404':
+          description: Discipline not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Deletion error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/classes/templates:
+    get:
+      tags: [Classes]
+      summary: List class templates
+      operationId: listClassTemplates
+      responses:
+        '200':
+          description: Class templates
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ClassTemplate'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    post:
+      tags: [Classes]
+      summary: Create a class template
+      operationId: createClassTemplate
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClassTemplate'
+      responses:
+        '201':
+          description: Template created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ClassTemplate'
+        '500':
+          description: Creation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/classes/templates/{slug}:
+    get:
+      tags: [Classes]
+      summary: Get a class template by slug
+      operationId: getClassTemplateBySlug
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Class template
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ClassTemplate'
+        '404':
+          description: Class template not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/classes/templates/{id}:
+    put:
+      tags: [Classes]
+      summary: Update a class template
+      operationId: updateClassTemplate
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClassTemplate'
+      responses:
+        '200':
+          description: Template updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ClassTemplate'
+        '404':
+          description: Class template not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Update error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    delete:
+      tags: [Classes]
+      summary: Delete a class template
+      operationId: deleteClassTemplate
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Template deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          success:
+                            type: boolean
+        '404':
+          description: Class template not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Deletion error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/coaches:
+    get:
+      tags: [Coaches]
+      summary: List coaches
+      operationId: listCoaches
+      parameters:
+        - in: query
+          name: specialty
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Coaches
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Coach'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    post:
+      tags: [Coaches]
+      summary: Create a coach profile
+      operationId: createCoach
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Coach'
+      responses:
+        '201':
+          description: Coach created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Coach'
+        '500':
+          description: Creation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/coaches/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    get:
+      tags: [Coaches]
+      summary: Get coach details
+      operationId: getCoach
+      responses:
+        '200':
+          description: Coach details
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Coach'
+        '404':
+          description: Coach not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    put:
+      tags: [Coaches]
+      summary: Update a coach profile
+      operationId: updateCoach
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Coach'
+      responses:
+        '200':
+          description: Coach updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Coach'
+        '404':
+          description: Coach not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Update error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    delete:
+      tags: [Coaches]
+      summary: Delete a coach profile
+      operationId: deleteCoach
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Coach deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          success:
+                            type: boolean
+        '404':
+          description: Coach not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Deletion error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/coaches/{id}/booked-sessions:
+    get:
+      tags: [Coaches]
+      summary: List sessions booked with a coach
+      operationId: getCoachBookedSessions
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Booked sessions
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/BookedSession'
+        '404':
+          description: Coach not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/membership-plans:
+    get:
+      tags: [Membership]
+      summary: List membership plans
+      operationId: listMembershipPlans
+      responses:
+        '200':
+          description: Membership plans
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/MembershipPlan'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    post:
+      tags: [Membership]
+      summary: Create a membership plan
+      operationId: createMembershipPlan
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MembershipPlan'
+      responses:
+        '201':
+          description: Plan created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/MembershipPlan'
+        '500':
+          description: Creation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/membership-plans/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    get:
+      tags: [Membership]
+      summary: Get membership plan details
+      operationId: getMembershipPlan
+      responses:
+        '200':
+          description: Membership plan
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/MembershipPlan'
+        '404':
+          description: Plan not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    put:
+      tags: [Membership]
+      summary: Update a membership plan
+      operationId: updateMembershipPlan
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MembershipPlan'
+      responses:
+        '200':
+          description: Plan updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/MembershipPlan'
+        '404':
+          description: Plan not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Update error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    delete:
+      tags: [Membership]
+      summary: Delete a membership plan
+      operationId: deleteMembershipPlan
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Plan deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/MembershipPlan'
+        '404':
+          description: Plan not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Deletion error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/shop/categories:
+    get:
+      tags: [Shop]
+      summary: List product categories
+      operationId: listShopCategories
+      responses:
+        '200':
+          description: Categories
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ProductCategory'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/shop/products:
+    get:
+      tags: [Shop]
+      summary: Search and list products
+      operationId: listProducts
+      parameters:
+        - in: query
+          name: query
+          schema:
+            type: string
+        - in: query
+          name: categoryId
+          schema:
+            type: string
+        - in: query
+          name: inStock
+          schema:
+            type: boolean
+        - in: query
+          name: sort
+          schema:
+            type: string
+            enum: [price_asc, price_desc, name_asc]
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 12
+      responses:
+        '200':
+          description: Paginated products
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Product'
+                      meta:
+                        $ref: '#/components/schemas/PaginationMeta'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    post:
+      tags: [Shop]
+      summary: Create a product
+      operationId: createProduct
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Product'
+      responses:
+        '201':
+          description: Product created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Product'
+        '500':
+          description: Creation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/shop/products/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    get:
+      tags: [Shop]
+      summary: Get product details
+      operationId: getProduct
+      responses:
+        '200':
+          description: Product details
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Product'
+        '404':
+          description: Product not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    put:
+      tags: [Shop]
+      summary: Update a product
+      operationId: updateProduct
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Product'
+      responses:
+        '200':
+          description: Product updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Product'
+        '404':
+          description: Product not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Update error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    delete:
+      tags: [Shop]
+      summary: Soft-delete a product
+      operationId: deleteProduct
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Product deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          success:
+                            type: boolean
+        '404':
+          description: Product not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Deletion error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/shop/cart:
+    post:
+      tags: [Shop]
+      summary: Build a cart for checkout
+      operationId: createCart
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [userId, items]
+              properties:
+                userId:
+                  type: string
+                items:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: object
+                    required: [productId, quantity]
+                    properties:
+                      productId:
+                        type: string
+                      variantId:
+                        type: string
+                      quantity:
+                        type: integer
+                        minimum: 1
+      responses:
+        '200':
+          description: Calculated cart summary
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Cart'
+        '400':
+          description: Invalid payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/shop/whatsapp-config:
+    get:
+      tags: [Shop]
+      summary: Retrieve WhatsApp ordering configuration
+      operationId: getWhatsappConfig
+      responses:
+        '200':
+          description: WhatsApp configuration
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          phoneE164:
+                            type: string
+                          template:
+                            type: string
+  /api/me:
+    get:
+      tags: [User]
+      summary: Get the authenticated user's profile
+      operationId: getCurrentUser
+      responses:
+        '200':
+          description: Current user profile
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/User'
+  /api/me/bookings:
+    get:
+      tags: [User]
+      summary: List bookings for the current user
+      operationId: listUserBookings
+      responses:
+        '200':
+          description: User bookings
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            sessionId:
+                              type: string
+                            status:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            session:
+                              type: object
+                              properties:
+                                id:
+                                  type: string
+                                startAt:
+                                  type: string
+                                  format: date-time
+                                endAt:
+                                  type: string
+                                  format: date-time
+                                template:
+                                  type: object
+                                  properties:
+                                    title:
+                                      type: string
+                                    level:
+                                      type: string
+                                coach:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                discipline:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+  /api/me/orders:
+    get:
+      tags: [User]
+      summary: List orders for the current user
+      operationId: listUserOrders
+      responses:
+        '200':
+          description: User orders
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Order'


### PR DESCRIPTION
## Summary
- regenerate the OpenAPI 3.0 specification with current metadata, security, and shared schemas
- document every available API route including auth, admin, content, classes, coaches, membership, shop, and user endpoints

## Testing
- `node -e "require('yamljs').load('swagger.yaml'); console.log('Swagger YAML parsed successfully');"`


------
https://chatgpt.com/codex/tasks/task_e_68d18e639648832db2525f70609f92d7