### PR TITLE
Document coach booked session creation endpoint

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1436,6 +1436,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
+    post:
+      tags: [Coaches]
+      summary: Add a booked session for a coach
+      operationId: addCoachBookedSession
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookedSession'
+      responses:
+        '201':
+          description: Booked session created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/BookedSession'
+        '404':
+          description: Coach not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Creation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
   /api/membership-plans:
     get:
       tags: [Membership]


### PR DESCRIPTION
## Summary
- document the POST /api/coaches/{id}/booked-sessions endpoint
- describe the request payload and success/error responses for adding a booked session

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d1914feddc832da0cd0dd7aac28076