### PR TITLE
feat: allow admins to upload images

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import cors from 'cors';
 import express from 'express';
+import fs from 'fs';
 import helmet from 'helmet';
 import path from 'path';
 import swaggerUi from 'swagger-ui-express';
@@ -30,6 +31,12 @@ app.use(helmet({
     crossOriginResourcePolicy: false,
 }));
 const STATIC_DIR = path.resolve(__dirname, 'public');
+const ASSETS_DIR = path.resolve(__dirname, '../assets');
+
+if (!fs.existsSync(ASSETS_DIR)) {
+  fs.mkdirSync(ASSETS_DIR, { recursive: true });
+}
+
 console.log('Serving static from:', STATIC_DIR);
 
 app.use(cors({
@@ -40,6 +47,14 @@ app.use(cors({
 app.use(
   '/static',
   express.static(STATIC_DIR, {
+    maxAge: '1d',
+    etag: true,
+  })
+);
+
+app.use(
+  '/assets',
+  express.static(ASSETS_DIR, {
     maxAge: '1d',
     etag: true,
   })

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,14 +1,63 @@
 import express from 'express';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { requireAdmin } from '../middleware/requireAdmin';
 import { ContentService } from '../services/contentService';
 import { ProductService } from '../services/productService';
 import { ApiResponse } from '../types';
 import { DisciplineService } from '../services/disciplineService';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..');
+const UPLOAD_DIR = path.resolve(PROJECT_ROOT, 'assets', 'uploaded-images');
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
+const ALLOWED_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp']);
+
 const router = express.Router();
 
 // Apply admin middleware to all routes
 router.use(requireAdmin);
+
+const ensureUploadDirectory = async () => {
+  await fs.mkdir(UPLOAD_DIR, { recursive: true });
+};
+
+const sanitizeFileName = (fileName: string) => {
+  const rawExtension = path.extname(fileName);
+  const baseName = path.basename(fileName, rawExtension);
+  const sanitizedBase = baseName.replace(/[^a-zA-Z0-9._-]/g, '_');
+  const sanitizedExtension = rawExtension
+    .toLowerCase()
+    .replace(/[^a-z0-9.]/g, '');
+
+  const finalBase = sanitizedBase || 'image';
+  const finalExtension = sanitizedExtension.startsWith('.')
+    ? sanitizedExtension
+    : sanitizedExtension
+    ? `.${sanitizedExtension}`
+    : '';
+
+  return `${finalBase}${finalExtension}`;
+};
+
+const getUniqueFileName = async (desiredName: string) => {
+  const extension = path.extname(desiredName).toLowerCase();
+  const base = path.basename(desiredName, extension);
+  let uniqueName = desiredName;
+  let counter = 1;
+
+  while (true) {
+    try {
+      await fs.access(path.join(UPLOAD_DIR, uniqueName));
+      uniqueName = `${base}-${counter}${extension}`;
+      counter += 1;
+    } catch {
+      return uniqueName;
+    }
+  }
+};
 
 // GET /api/admin/content
 router.get('/content', async (req, res) => {
@@ -85,6 +134,80 @@ router.get('/product-categories', async (req, res) => {
     res.status(500).json({
       error: 'Internal Server Error',
       message: 'Failed to fetch product categories'
+    });
+  }
+});
+
+router.post('/upload-image', async (req, res) => {
+  const { fileName, imageData } = req.body as { fileName?: string; imageData?: string };
+
+  if (!fileName || !imageData) {
+    return res.status(400).json({
+      error: 'Bad Request',
+      message: 'Both fileName and imageData are required',
+    });
+  }
+
+  const sanitizedName = sanitizeFileName(fileName);
+  const extension = path.extname(sanitizedName).toLowerCase();
+  const nameWithoutExtension = path.basename(sanitizedName, extension);
+
+  if (!extension || !ALLOWED_EXTENSIONS.has(extension) || !nameWithoutExtension) {
+    return res.status(400).json({
+      error: 'Unsupported Media Type',
+      message: `File extension ${extension || 'unknown'} is not allowed`,
+    });
+  }
+
+  const dataUrlMatch = imageData.match(/^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/);
+  const base64Payload = (dataUrlMatch ? dataUrlMatch[2] : imageData).replace(/\s/g, '');
+
+  let buffer: Buffer;
+  try {
+    buffer = Buffer.from(base64Payload, 'base64');
+  } catch (error) {
+    console.error('Failed to decode base64 image data', error);
+    return res.status(400).json({
+      error: 'Bad Request',
+      message: 'Invalid base64 image data',
+    });
+  }
+
+  if (!buffer.length) {
+    return res.status(400).json({
+      error: 'Bad Request',
+      message: 'Image data is empty',
+    });
+  }
+
+  if (buffer.length > MAX_FILE_SIZE_BYTES) {
+    return res.status(413).json({
+      error: 'Payload Too Large',
+      message: 'Image exceeds the maximum allowed size of 5MB',
+    });
+  }
+
+  try {
+    await ensureUploadDirectory();
+    const uniqueFileName = await getUniqueFileName(sanitizedName);
+    const filePath = path.join(UPLOAD_DIR, uniqueFileName);
+    await fs.writeFile(filePath, buffer);
+
+    const relativePath = path.relative(PROJECT_ROOT, filePath).split(path.sep).join('/');
+    const response: ApiResponse<{ fileName: string; path: string; url: string }> = {
+      data: {
+        fileName: uniqueFileName,
+        path: relativePath,
+        url: `/assets/uploaded-images/${uniqueFileName}`,
+      },
+    };
+
+    res.status(201).json(response);
+  } catch (error) {
+    console.error('Failed to save uploaded image', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to store uploaded image',
     });
   }
 });


### PR DESCRIPTION
## Summary
- add static assets directory support so uploaded images can be served publicly
- implement an admin image upload endpoint that stores validated base64 images under assets/uploaded-images
- ensure upload directory exists in the repository structure

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d1c07d6198832d9e61c38038f5679d