### PR TITLE
Add endpoint for public coach booked sessions

### DIFF
--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -65,6 +65,7 @@ const socialLinkSchema = new Schema<ISocialLink>({
 const bookedSessionSchema = new Schema<IBookedSession>({
   templateId: { type: String, trim: true },
   name: { type: String, trim: true },
+  isPrivate: { type: Boolean, default: false },
   sessionDate: { type: Date, required: true },
   repetition: {
     type: String,

--- a/src/routes/coaches.ts
+++ b/src/routes/coaches.ts
@@ -6,10 +6,16 @@ import { requireAdmin } from '../middleware/requireAdmin';
 
 const router = express.Router();
 
+interface ICoachPublicBookedSessions {
+  coachId: string;
+  coachName: string;
+  bookedSessions: IBookedSession[];
+}
+
 // GET /api/coaches
 router.get('/', async (req, res) => {
   const { specialty } = req.query;
-  
+
   try {
     const coaches = await CoachService.getAllCoaches(specialty as string);
     
@@ -42,10 +48,29 @@ router.post('/', requireAdmin, async (req, res) => {
   }
 });
 
+// GET /api/coaches/booked-sessions
+router.get('/booked-sessions', async (_req, res) => {
+  try {
+    const bookedSessions = await CoachService.getAllCoachesPublicBookedSessions();
+
+    const response: ApiResponse<ICoachPublicBookedSessions[]> = {
+      data: bookedSessions,
+    };
+
+    res.json(response);
+  } catch (error) {
+    console.error('Error fetching booked sessions for all coaches:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to fetch booked sessions for all coaches'
+    });
+  }
+});
+
 // GET /api/coaches/:id
 router.get('/:id', async (req, res) => {
   const { id } = req.params;
-  
+
   try {
     const coach = await CoachService.getCoachById(id);
     

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -85,6 +85,7 @@ export interface BookedSession {
   repetition: SessionRepetition;
   templateId?: string;
   name?: string;
+  isPrivate?: boolean;
 }
 
 export interface Coach {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -215,12 +215,30 @@ components:
           type: string
         name:
           type: string
+        isPrivate:
+          type: boolean
+          description: Indicates if the session is private and should not be shown publicly
         sessionDate:
           type: string
           format: date-time
         repetition:
           type: string
           enum: [daily, weekly, monthly]
+    CoachPublicBookedSessions:
+      type: object
+      required:
+        - coachId
+        - coachName
+        - bookedSessions
+      properties:
+        coachId:
+          type: string
+        coachName:
+          type: string
+        bookedSessions:
+          type: array
+          items:
+            $ref: '#/components/schemas/BookedSession'
     Coach:
       type: object
       required:
@@ -1291,6 +1309,31 @@ paths:
                         $ref: '#/components/schemas/Coach'
         '500':
           description: Creation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/coaches/booked-sessions:
+    get:
+      tags: [Coaches]
+      summary: List non-private booked sessions for all coaches
+      operationId: getAllCoachBookedSessions
+      responses:
+        '200':
+          description: Non-private booked sessions grouped by coach
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/CoachPublicBookedSessions'
+        '500':
+          description: Retrieval error
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary
- add a coaches API route and service method to return non-private booked sessions for every coach
- include isPrivate flags in booked session models and types so private sessions can be filtered out
- document the endpoint and field changes in the Swagger definition

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5256cdce0832db0bce331a6b177be