### PR TITLE
feat: add order entity and CRUD endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { coachRoutes } from './routes/coaches';
 import { contentRoutes } from './routes/content';
 import { membershipPlanRoutes } from './routes/membership-plans';
 import { shopRoutes } from './routes/shop';
+import { orderRoutes } from './routes/orders';
 import { userRoutes } from './routes/user';
 
 // ESM-safe __dirname
@@ -86,6 +87,7 @@ app.use('/api/classes', classRoutes);
 app.use('/api/coaches', coachRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/shop', shopRoutes);
+app.use('/api/orders', orderRoutes);
 app.use('/api/membership-plans', membershipPlanRoutes);
 app.use('/api/me', userRoutes);
 

--- a/src/models/Order.ts
+++ b/src/models/Order.ts
@@ -1,0 +1,61 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+export enum OrderStatus {
+  PLACED = 'placed',
+  IN_DELIVERY = 'in_delivery',
+  COMPLETED = 'completed',
+}
+
+export interface IOrderCustomer {
+  name: string;
+  email: string;
+  phoneNumber: string;
+  paymentMethod: string;
+}
+
+export interface IOrderProduct {
+  productId: mongoose.Types.ObjectId;
+  quantity: number;
+}
+
+export interface IOrder extends Document {
+  customer: IOrderCustomer;
+  products: IOrderProduct[];
+  deliveryMethod: string;
+  status: OrderStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const orderCustomerSchema = new Schema<IOrderCustomer>({
+  name: { type: String, required: true, trim: true },
+  email: { type: String, required: true, lowercase: true, trim: true },
+  phoneNumber: { type: String, required: true, trim: true },
+  paymentMethod: { type: String, required: true, trim: true },
+}, { _id: false });
+
+const orderProductSchema = new Schema<IOrderProduct>({
+  productId: { type: Schema.Types.ObjectId, ref: 'Product', required: true },
+  quantity: { type: Number, required: true, min: 1 },
+}, { _id: false });
+
+const orderSchema = new Schema<IOrder>({
+  customer: { type: orderCustomerSchema, required: true },
+  products: {
+    type: [orderProductSchema],
+    required: true,
+    validate: {
+      validator: (value: IOrderProduct[]) => Array.isArray(value) && value.length > 0,
+      message: 'At least one product is required',
+    },
+  },
+  deliveryMethod: { type: String, required: true, trim: true },
+  status: { type: String, enum: Object.values(OrderStatus), default: OrderStatus.PLACED },
+}, {
+  timestamps: true,
+});
+
+orderSchema.index({ status: 1 });
+orderSchema.index({ 'customer.email': 1 });
+
+export const Order = mongoose.model<IOrder>('Order', orderSchema);

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -5,5 +5,6 @@ export { Coach, type IBookedSession, type ICoach, type ISocialLink } from './Coa
 export { ContentBlock, type IContentBlock } from './ContentBlock';
 export { MembershipPlan, type IMembershipPlan } from './MembershipPlan';
 export { Product, ProductCategory, type IProduct, type IProductAttribute, type IProductCategory, type IProductVariant } from './Product';
+export { Order, type IOrder, type IOrderCustomer, type IOrderProduct, OrderStatus } from './Order';
 export { User, type IMembership, type IUser } from './User';
 

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -1,0 +1,148 @@
+import express from 'express';
+import { OrderStatus } from '../models';
+import { OrderService, type CreateOrderInput, type UpdateOrderInput } from '../services/orderService';
+import { ApiResponse } from '../types';
+
+const router = express.Router();
+
+router.get('/', async (_req, res) => {
+  try {
+    const orders = await OrderService.getOrders();
+    const response: ApiResponse<any> = { data: orders };
+    res.json(response);
+  } catch (error) {
+    console.error('Error fetching orders:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to fetch orders',
+    });
+  }
+});
+
+router.get('/:id', async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const order = await OrderService.getOrderById(id);
+
+    if (!order) {
+      return res.status(404).json({
+        error: 'Order Not Found',
+        message: `Order with id "${id}" not found`,
+      });
+    }
+
+    const response: ApiResponse<any> = { data: order };
+    res.json(response);
+  } catch (error) {
+    console.error('Error fetching order:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to fetch order',
+    });
+  }
+});
+
+router.post('/', async (req, res) => {
+  const data = req.body as CreateOrderInput;
+
+  if (!data?.customer || !data?.products || !Array.isArray(data.products) || data.products.length === 0) {
+    return res.status(400).json({
+      error: 'Validation Error',
+      message: 'customer and at least one product are required',
+    });
+  }
+
+  const requiredCustomerFields: (keyof CreateOrderInput['customer'])[] = ['name', 'email', 'phoneNumber', 'paymentMethod'];
+  const missingCustomerField = requiredCustomerFields.find(field => !data.customer?.[field]);
+  if (missingCustomerField) {
+    return res.status(400).json({
+      error: 'Validation Error',
+      message: `Customer ${missingCustomerField} is required`,
+    });
+  }
+
+  if (!data.deliveryMethod) {
+    return res.status(400).json({
+      error: 'Validation Error',
+      message: 'deliveryMethod is required',
+    });
+  }
+
+  if (data.status && !Object.values(OrderStatus).includes(data.status)) {
+    return res.status(400).json({
+      error: 'Validation Error',
+      message: 'Invalid order status',
+    });
+  }
+
+  try {
+    const order = await OrderService.createOrder(data);
+    const response: ApiResponse<any> = { data: order };
+    res.status(201).json(response);
+  } catch (error) {
+    console.error('Error creating order:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to create order',
+    });
+  }
+});
+
+router.put('/:id', async (req, res) => {
+  const { id } = req.params;
+  const data = req.body as UpdateOrderInput;
+
+  if (data.status && !Object.values(OrderStatus).includes(data.status)) {
+    return res.status(400).json({
+      error: 'Validation Error',
+      message: 'Invalid order status',
+    });
+  }
+
+  try {
+    const order = await OrderService.updateOrder(id, data);
+
+    if (!order) {
+      return res.status(404).json({
+        error: 'Order Not Found',
+        message: `Order with id "${id}" not found`,
+      });
+    }
+
+    const response: ApiResponse<any> = { data: order };
+    res.json(response);
+  } catch (error) {
+    console.error('Error updating order:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to update order',
+    });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const order = await OrderService.deleteOrder(id);
+
+    if (!order) {
+      return res.status(404).json({
+        error: 'Order Not Found',
+        message: `Order with id "${id}" not found`,
+      });
+    }
+
+    const response: ApiResponse<any> = { data: { success: true } };
+    res.json(response);
+  } catch (error) {
+    console.error('Error deleting order:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to delete order',
+    });
+  }
+});
+
+export const orderRoutes = router;

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -1,0 +1,44 @@
+import { Order, type IOrder, type IOrderCustomer, OrderStatus } from '../models';
+
+export interface OrderProductInput {
+  productId: string;
+  quantity: number;
+}
+
+export interface OrderCustomerInput extends IOrderCustomer {}
+
+export interface CreateOrderInput {
+  customer: OrderCustomerInput;
+  products: OrderProductInput[];
+  deliveryMethod: string;
+  status?: OrderStatus;
+}
+
+export type UpdateOrderInput = Partial<CreateOrderInput>;
+
+export class OrderService {
+  static async getOrders(): Promise<IOrder[]> {
+    return Order.find({}).sort({ createdAt: -1 }).populate('products.productId', 'title price sku');
+  }
+
+  static async getOrderById(id: string): Promise<IOrder | null> {
+    return Order.findById(id).populate('products.productId', 'title price sku');
+  }
+
+  static async createOrder(data: CreateOrderInput): Promise<IOrder> {
+    const orderData = {
+      ...data,
+      status: data.status ?? OrderStatus.PLACED,
+    };
+
+    return Order.create(orderData);
+  }
+
+  static async updateOrder(id: string, data: UpdateOrderInput): Promise<IOrder | null> {
+    return Order.findByIdAndUpdate(id, data, { new: true, runValidators: true }).populate('products.productId', 'title price sku');
+  }
+
+  static async deleteOrder(id: string): Promise<IOrder | null> {
+    return Order.findByIdAndDelete(id);
+  }
+}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -465,59 +465,85 @@ components:
           type: string
           format: date-time
           readOnly: true
+    OrderCustomer:
+      type: object
+      required:
+        - name
+        - email
+        - phoneNumber
+        - paymentMethod
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        phoneNumber:
+          type: string
+        paymentMethod:
+          type: string
     OrderItem:
       type: object
       required:
         - productId
         - quantity
-        - price
-        - title
       properties:
         productId:
           type: string
-        variantId:
-          type: string
         quantity:
           type: integer
-        price:
-          type: number
-        title:
-          type: string
+          minimum: 1
     Order:
       type: object
       required:
         - id
-        - total
+        - customer
+        - products
+        - deliveryMethod
         - status
         - createdAt
-        - items
+        - updatedAt
       properties:
         id:
           type: string
           readOnly: true
-        userId:
-          type: string
-        items:
+        customer:
+          $ref: '#/components/schemas/OrderCustomer'
+        products:
           type: array
           items:
             $ref: '#/components/schemas/OrderItem'
-        subtotal:
-          type: number
-          readOnly: true
-        tax:
-          type: number
-          readOnly: true
-        shipping:
-          type: number
-          readOnly: true
-        total:
-          type: number
-          readOnly: true
+        deliveryMethod:
+          type: string
         status:
           type: string
-          enum: [pending, paid, shipped, delivered, cancelled, refunded]
-        paymentIntentId:
+          enum: [placed, in_delivery, completed]
+        createdAt:
           type: string
+          format: date-time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          readOnly: true
+    OrderInput:
+      type: object
+      required:
+        - customer
+        - products
+        - deliveryMethod
+      properties:
+        customer:
+          $ref: '#/components/schemas/OrderCustomer'
+        products:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderItem'
+        deliveryMethod:
+          type: string
+        status:
+          type: string
+          enum: [placed, in_delivery, completed]
         shippingAddress:
           $ref: '#/components/schemas/Address'
         billingAddress:
@@ -1960,6 +1986,171 @@ paths:
                             type: string
                           template:
                             type: string
+  /api/orders:
+    get:
+      tags: [Orders]
+      summary: List orders
+      operationId: listOrders
+      responses:
+        '200':
+          description: Orders
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Order'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    post:
+      tags: [Orders]
+      summary: Create an order
+      operationId: createOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderInput'
+      responses:
+        '201':
+          description: Order created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Order'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Creation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /api/orders/{orderId}:
+    parameters:
+      - in: path
+        name: orderId
+        required: true
+        schema:
+          type: string
+    get:
+      tags: [Orders]
+      summary: Get an order
+      operationId: getOrder
+      responses:
+        '200':
+          description: Order details
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Order'
+        '404':
+          description: Order not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    put:
+      tags: [Orders]
+      summary: Update an order
+      operationId: updateOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderInput'
+      responses:
+        '200':
+          description: Updated order
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Order'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '404':
+          description: Order not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Update error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    delete:
+      tags: [Orders]
+      summary: Delete an order
+      operationId: deleteOrder
+      responses:
+        '200':
+          description: Order deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          success:
+                            type: boolean
+        '404':
+          description: Order not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Deletion error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
   /api/me:
     get:
       tags: [User]


### PR DESCRIPTION
## Summary
- add a dedicated Mongoose order model with customer details, products, delivery method, and status tracking
- implement an order service and Express router providing CRUD APIs for orders
- document the order schemas and endpoints in Swagger and expose the routes through the main server

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d52c8add4c832db10f235fed3091b1