### PR TITLE
Add endpoint to fetch class templates by discipline

### DIFF
--- a/src/routes/classes.ts
+++ b/src/routes/classes.ts
@@ -101,6 +101,27 @@ router.get('/templates', async (req, res) => {
   }
 });
 
+// GET /api/classes/templates/discipline/:disciplineId
+router.get('/templates/discipline/:disciplineId', async (req, res) => {
+  const { disciplineId } = req.params;
+
+  try {
+    const templates = await DisciplineService.getClassTemplatesByDisciplineId(disciplineId);
+
+    const response: ApiResponse<any> = {
+      data: templates,
+    };
+
+    res.json(response);
+  } catch (error) {
+    console.error('Error fetching templates by discipline:', error);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: 'Failed to fetch templates by discipline'
+    });
+  }
+});
+
 // POST /api/classes/templates
 router.post('/templates', requireAdmin, async (req, res) => {
   try {

--- a/src/services/disciplineService.ts
+++ b/src/services/disciplineService.ts
@@ -33,6 +33,12 @@ export class DisciplineService {
         return ClassTemplate.find().populate('disciplineId').sort({ name: 1 });
     }
 
+    static async getClassTemplatesByDisciplineId(disciplineId: string) {
+        return ClassTemplate.find({ disciplineId })
+                .populate('disciplineId')
+                .sort({ title: 1 });
+    }
+
     static async createClassTemplate(data: {
         disciplineId: string;
         title: string;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1162,6 +1162,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
+  /api/classes/templates/discipline/{disciplineId}:
+    get:
+      tags: [Classes]
+      summary: List class templates for a discipline
+      operationId: listClassTemplatesByDiscipline
+      parameters:
+        - in: path
+          name: disciplineId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Class templates for a discipline
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ClassTemplate'
+        '500':
+          description: Retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
   /api/classes/templates/{slug}:
     get:
       tags: [Classes]


### PR DESCRIPTION
## Summary
- add a service helper to load class templates filtered by discipline
- expose a GET /api/classes/templates/discipline/:disciplineId endpoint that returns the filtered templates
- document the new endpoint in the OpenAPI specification

## Testing
- not run (project does not define an automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68d542f0bb38832dae6a43693874ad6f