### PR TITLE
Add production TypeScript build config

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "types": ["node"],
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmitOnError": true,
+    "sourceMap": false,
+    "declaration": false,
+    "removeComments": true,
+    "incremental": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- add a dedicated `tsconfig.build.json` tuned for generating production builds from the `src` directory
- configure ES2022 output, bundler-style module resolution, and standard Node interoperability flags for the compiled API server

## Testing
- npx tsc -p tsconfig.build.json *(fails: existing type errors in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d587bb35a4832dbd6f5d4baa287f4b